### PR TITLE
fix: generator download rc templates for test

### DIFF
--- a/packages/fx-core/src/component/generator/generatorAction.ts
+++ b/packages/fx-core/src/component/generator/generatorAction.ts
@@ -14,10 +14,9 @@ import {
   fetchZipFromUrl,
   getSampleInfoFromName,
   unzip,
-  getTemplateLatestTag,
+  getTemplateUrl,
+  getTemplateLatestVersion,
 } from "./utils";
-import semver from "semver";
-import templateConfig from "../../common/templates-config.json";
 import { SampleUrlInfo } from "../../common/samples";
 
 export interface GeneratorContext {
@@ -59,8 +58,12 @@ export enum GeneratorActionName {
 export const ScaffoldRemoteTemplateAction: GeneratorAction = {
   name: GeneratorActionName.ScaffoldRemoteTemplate,
   run: async (context: GeneratorContext) => {
-    const templateUrl = await determineTemplateSource(context);
-    if (templateUrl === "local") {
+    if (!context.language) {
+      throw new MissKeyError("language");
+    }
+
+    const templateUrl = await getTemplateUrl(context.language, getTemplateLatestVersion);
+    if (!templateUrl) {
       return;
     }
 
@@ -78,12 +81,16 @@ export const ScaffoldRemoteTemplateAction: GeneratorAction = {
 export const ScaffoldLocalTemplateAction: GeneratorAction = {
   name: GeneratorActionName.ScaffoldLocalTemplate,
   run: async (context: GeneratorContext) => {
+    if (!context.language) {
+      throw new MissKeyError("language");
+    }
+
     if (context.outputs?.length) {
       return;
     }
     context.logProvider.debug(`Fetching zip from local: ${JSON.stringify(context)}`);
     const fallbackPath = path.join(getTemplatesFolder(), "fallback");
-    const fileName = `${context.language!}.zip`;
+    const fileName = `${context.language}.zip`;
     const zipPath: string = path.join(fallbackPath, fileName);
 
     const data: Buffer = await fs.readFile(zipPath);
@@ -101,23 +108,6 @@ export const ScaffoldLocalTemplateAction: GeneratorAction = {
     }
   },
 };
-
-async function determineTemplateSource(context: GeneratorContext) {
-  let url = "local";
-  if (!Boolean(templateConfig.useLocalTemplate)) {
-    let latestTag = await getTemplateLatestTag(
-      context.language!,
-      context.tryLimits,
-      context.timeoutInMs
-    );
-    latestTag = latestTag.replace(templateConfig.tagPrefix, "").trim();
-    if (semver.gt(latestTag, templateConfig.localVersion)) {
-      // git tag version is higher than the local version, download template from github
-      url = `${templateConfig.templateDownloadBaseURL}/${latestTag}/${context.language!}.zip`;
-    }
-  }
-  return url;
-}
 
 export const fetchSampleInfoAction: GeneratorAction = {
   name: GeneratorActionName.FetchSampleInfo,

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -26,6 +26,8 @@ import {
   ScaffoldRemoteTemplateAction,
   fetchSampleInfoAction,
   TemplateActionSeq,
+  GeneratorContext,
+  ScaffoldLocalTemplateAction,
 } from "../../../src/component/generator/generatorAction";
 import * as generatorUtils from "../../../src/component/generator/utils";
 import * as requestUtils from "../../../src/common/requestUtils";
@@ -664,6 +666,23 @@ describe("Generator error", async () => {
     };
     const error = new DownloadSampleApiLimitError(url, mockError);
     assert.deepEqual(error.innerError, simplifyAxiosError(mockError));
+  });
+
+  it("scaffold remote, missing key error: language", async () => {
+    try {
+      const ctx = { name: "bot", destination: tmpDir } as GeneratorContext;
+      await ScaffoldRemoteTemplateAction.run(ctx);
+    } catch (err: any) {
+      assert.equal(err?.name, "MissingKeyError");
+    }
+  });
+  it("scaffold local, missing key error: language", async () => {
+    try {
+      const ctx = { name: "bot", destination: tmpDir } as GeneratorContext;
+      await ScaffoldLocalTemplateAction.run(ctx);
+    } catch (err: any) {
+      assert.equal(err?.name, "MissingKeyError");
+    }
   });
 });
 

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -121,8 +121,8 @@ describe("Generator utils", () => {
     sandbox.replace(templateConfig, "useLocalTemplate", false);
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
     const templateName = "templateName";
-    const selectedTag = await generatorUtils.getTemplateLatestTag(templateName);
-    const url = generatorUtils.getTemplateZipUrlByTag(templateName, selectedTag);
+    const selectedTag = await generatorUtils.getTemplateLatestVersion();
+    const url = generatorUtils.getTemplateZipUrlByVersion(templateName, selectedTag);
     assert.isTrue(url.includes("0.0.0-rc"));
   });
 
@@ -134,7 +134,7 @@ describe("Generator utils", () => {
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0";
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
     try {
-      await generatorUtils.getTemplateLatestTag("templateName");
+      await generatorUtils.getTemplateLatestVersion();
     } catch (e) {
       assert.exists(e);
       return;
@@ -153,8 +153,8 @@ describe("Generator utils", () => {
     sandbox.stub(templateConfig, "version").value("^2.0.0");
     sandbox.replace(templateConfig, "tagPrefix", "templates@");
     const templateName = "templateName";
-    const selectedTag = await generatorUtils.getTemplateLatestTag(templateName);
-    const url = generatorUtils.getTemplateZipUrlByTag(templateName, selectedTag);
+    const selectedTag = await generatorUtils.getTemplateLatestVersion();
+    const url = generatorUtils.getTemplateZipUrlByVersion(templateName, selectedTag);
     assert.isTrue(url.includes(tag));
   });
 
@@ -167,7 +167,7 @@ describe("Generator utils", () => {
     sandbox.stub(templateConfig, "version").value("^4.0.0");
     sandbox.replace(templateConfig, "tagPrefix", "templates@");
     try {
-      await generatorUtils.getTemplateLatestTag("templateName");
+      await generatorUtils.getTemplateLatestVersion();
     } catch (e) {
       assert.exists(e);
       return;
@@ -751,6 +751,7 @@ describe("render template", () => {
     const tmpDir = path.join(__dirname, "tmp");
     const templateName = TemplateNames.DefaultBot;
     const language = "ts";
+    let mockedEnvRestore: RestoreFn = () => {};
 
     async function buildFakeTemplateZip(templateName: string, mockFileName: string) {
       const mockFileData = "test data";
@@ -777,6 +778,7 @@ describe("render template", () => {
       if (await fs.pathExists(tmpDir)) {
         await fs.rm(tmpDir, { recursive: true });
       }
+      mockedEnvRestore();
     });
 
     it("external sample", async () => {
@@ -813,7 +815,7 @@ describe("render template", () => {
       const zip = new AdmZip();
       zip.addLocalFolder(inputDir);
       zip.writeZip(path.join(tmpDir, "test.zip"));
-      sandbox.stub(generatorUtils, "getTemplateZipUrlByTag").resolves("test.zip");
+      sandbox.stub(generatorUtils, "getTemplateZipUrlByVersion").resolves("test.zip");
       sandbox
         .stub(generatorUtils, "fetchZipFromUrl")
         .resolves(new AdmZip(path.join(tmpDir, "test.zip")));
@@ -1031,7 +1033,7 @@ describe("render template", () => {
       sandbox.replace(templateConfig, "localVersion", "9.9.9");
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
       sandbox
-        .stub(generatorUtils, "getTemplateZipUrlByTag")
+        .stub(generatorUtils, "getTemplateZipUrlByVersion")
         .resolves("fooUrl/templates@0.1.0/test.zip");
 
       const result = newGeneratorFlag
@@ -1059,7 +1061,38 @@ describe("render template", () => {
       sandbox.replace(templateConfig, "useLocalTemplate", false);
       sandbox.replace(templateConfig, "localVersion", "0.1.0");
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
-      sandbox.stub(generatorUtils, "getTemplateLatestTag").resolves("templates@0.1.1");
+      sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("0.1.1");
+      sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(zip);
+
+      const result = newGeneratorFlag
+        ? await new DefaultTemplateGenerator().run(context, inputs, tmpDir, actionContext)
+        : await Generator.generateTemplate(context, tmpDir, templateName, language, actionContext);
+
+      const isFallback = actionContext.telemetryProps?.fallback === "true";
+      if (isFallback === true) {
+        assert.fail("template should not be generated from remote to local");
+      }
+
+      if (!fs.existsSync(path.join(tmpDir, mockFileName))) {
+        assert.fail("local template creation failure");
+      }
+      assert.isTrue(result.isOk());
+    });
+
+    it("template from downloading when TEAMSFX_TEMPLATE_PRERELEASE feature flag is set", async () => {
+      const mockFileName = "test.txt";
+      const zip = await buildFakeTemplateZip(templateName, mockFileName);
+      const actionContext: ActionContext = {
+        telemetryProps: {},
+      };
+
+      mockedEnvRestore = mockedEnv({
+        TEAMSFX_TEMPLATE_PRERELEASE: "rc",
+      });
+      sandbox.replace(templateConfig, "useLocalTemplate", false);
+      sandbox.replace(templateConfig, "localVersion", "0.1.0");
+      sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
+      sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("0.1.1");
       sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(zip);
 
       const result = newGeneratorFlag

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -668,12 +668,13 @@ describe("Generator error", async () => {
     assert.deepEqual(error.innerError, simplifyAxiosError(mockError));
   });
 
-  it("scaffold remote, missing key error: language", async () => {
+  it("scaffold remote, miss key error: language", async () => {
     try {
       const ctx = { name: "bot", destination: tmpDir } as GeneratorContext;
       await ScaffoldRemoteTemplateAction.run(ctx);
     } catch (err: any) {
-      assert.equal(err?.name, "MissingKeyError");
+      assert.equal(err?.name, "MissKeyError");
+      assert.include(err?.message, "language");
     }
   });
   it("scaffold local, missing key error: language", async () => {
@@ -681,7 +682,8 @@ describe("Generator error", async () => {
       const ctx = { name: "bot", destination: tmpDir } as GeneratorContext;
       await ScaffoldLocalTemplateAction.run(ctx);
     } catch (err: any) {
-      assert.equal(err?.name, "MissingKeyError");
+      assert.equal(err?.name, "MissKeyError");
+      assert.include(err?.message, "language");
     }
   });
 });

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -120,10 +120,11 @@ describe("Generator utils", () => {
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0\n 0.0.0-rc";
     sandbox.replace(templateConfig, "useLocalTemplate", false);
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
-    const templateName = "templateName";
-    const selectedTag = await generatorUtils.getTemplateLatestVersion();
-    const url = generatorUtils.getTemplateZipUrlByVersion(templateName, selectedTag);
-    assert.isTrue(url.includes("0.0.0-rc"));
+    const url = await generatorUtils.getTemplateUrl(
+      "templateName",
+      generatorUtils.getTemplateLatestVersion
+    );
+    assert.isTrue(url?.includes("0.0.0-rc"));
   });
 
   it("set useLocalTemplate flag to true", async () => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28066566

The expected behavior is:
1. If `TEAMSFX_TEMPLATE_PRERELEASE` has value, typically is `rc`, TTK downloads prerelease templates from GitHub releases.
2. Else if, `useLocalTemplate` config is false, TTK gets latest templates version who matches the version pattern in the config file, only download templates from GitHub releases when its version is greater than local template version.
3. Else, TTK uses the templates snapshot in TTK for scaffolding.