### PR TITLE
fix: set perScriptSourcemaps to stabilize the debugger

### DIFF
--- a/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/ai-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-bot/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/command-and-response/.vscode/launch.json.tpl
+++ b/templates/js/command-and-response/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-rag-customize/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-customize/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/default-bot-message-extension/.vscode/launch.json
+++ b/templates/js/default-bot-message-extension/.vscode/launch.json
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/default-bot/.vscode/launch.json.tpl
+++ b/templates/js/default-bot/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/message-extension-action/.vscode/launch.json.tpl
+++ b/templates/js/message-extension-action/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/notification-http-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-trigger/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/notification-restify/.vscode/launch.json.tpl
+++ b/templates/js/notification-restify/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",

--- a/templates/js/workflow/.vscode/launch.json.tpl
+++ b/templates/js/workflow/.vscode/launch.json.tpl
@@ -49,7 +49,8 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
             "name": "Attach to Local Service",


### PR DESCRIPTION
Fixes https://github.com/OfficeDev/teams-toolkit/issues/11732

Notes:
- I do not use the other debugging mode (like the `Launch Remote (Chrome)`) - might be needed there too
- I did not use the Typescript version neither but I assume the same problem might occur.