### PR TITLE
ci: update publish ci with node 18

### DIFF
--- a/.github/workflows/vscode-marketplace.yml
+++ b/.github/workflows/vscode-marketplace.yml
@@ -26,11 +26,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.CD_PAT }}


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs/issues/4019

according to this doc: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
the node.js version is 18 and npm is 10