### PR TITLE
perf(spec-parser): remove unused properties when filtering

### DIFF
--- a/packages/spec-parser/src/specFilter.ts
+++ b/packages/spec-parser/src/specFilter.ts
@@ -8,6 +8,7 @@ import { SpecParserError } from "./specParserError";
 import { ErrorType, ParseOptions } from "./interfaces";
 import { ConstantString } from "./constants";
 import { ValidatorFactory } from "./validators/validatorFactory";
+import { SpecOptimizer } from "./specOptimizer";
 
 export class SpecFilter {
   static specFilter(
@@ -55,7 +56,7 @@ export class SpecFilter {
       }
 
       newSpec.paths = newPaths;
-      return newSpec;
+      return SpecOptimizer.optimize(newSpec);
     } catch (err) {
       throw new SpecParserError((err as Error).toString(), ErrorType.FilterSpecFailed);
     }

--- a/packages/spec-parser/src/specOptimizer.ts
+++ b/packages/spec-parser/src/specOptimizer.ts
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import { OpenAPIV3 } from "openapi-types";
+
+export interface OptimizerOptions {
+  removeUnusedComponents: boolean;
+  removeUnusedTags: boolean;
+  removeUserDefinedRootProperty: boolean;
+  removeUnusedSecuritySchemas: boolean;
+}
+
+export class SpecOptimizer {
+  private static defaultOptions: OptimizerOptions = {
+    removeUnusedComponents: true,
+    removeUnusedTags: true,
+    removeUserDefinedRootProperty: true,
+    removeUnusedSecuritySchemas: true,
+  };
+
+  static optimize(spec: OpenAPIV3.Document, options?: OptimizerOptions): OpenAPIV3.Document {
+    const mergedOptions = {
+      ...SpecOptimizer.defaultOptions,
+      ...(options ?? {}),
+    } as Required<OptimizerOptions>;
+
+    const newSpec = JSON.parse(JSON.stringify(spec));
+
+    if (mergedOptions.removeUserDefinedRootProperty) {
+      SpecOptimizer.removeUserDefinedRootProperty(newSpec);
+    }
+
+    if (mergedOptions.removeUnusedComponents) {
+      SpecOptimizer.removeUnusedComponents(newSpec);
+    }
+
+    if (mergedOptions.removeUnusedTags) {
+      SpecOptimizer.removeUnusedTags(newSpec);
+    }
+
+    if (mergedOptions.removeUnusedSecuritySchemas) {
+      SpecOptimizer.removeUnusedSecuritySchemas(newSpec);
+    }
+
+    return newSpec;
+  }
+
+  private static removeUnusedSecuritySchemas(spec: OpenAPIV3.Document): void {
+    if (!spec.components || !spec.components.securitySchemes) {
+      return;
+    }
+
+    const usedSecuritySchemas = new Set<string>();
+
+    for (const pathKey in spec.paths) {
+      for (const methodKey in spec.paths[pathKey]) {
+        const operation: OpenAPIV3.OperationObject = (spec.paths[pathKey] as any)[methodKey];
+        if (operation.security) {
+          operation.security.forEach((securityReq) => {
+            for (const schemaKey in securityReq) {
+              usedSecuritySchemas.add(schemaKey);
+            }
+          });
+        }
+      }
+    }
+
+    if (spec.security) {
+      spec.security.forEach((securityReq) => {
+        for (const schemaKey in securityReq) {
+          usedSecuritySchemas.add(schemaKey);
+        }
+      });
+    }
+
+    for (const schemaKey in spec.components.securitySchemes) {
+      if (!usedSecuritySchemas.has(schemaKey)) {
+        delete spec.components.securitySchemes[schemaKey];
+      }
+    }
+
+    if (Object.keys(spec.components.securitySchemes).length === 0) {
+      delete spec.components.securitySchemes;
+    }
+
+    if (Object.keys(spec.components).length === 0) {
+      delete spec.components;
+    }
+  }
+
+  private static removeUnusedTags(spec: OpenAPIV3.Document): void {
+    if (!spec.tags) {
+      return;
+    }
+
+    const usedTags = new Set<string>();
+
+    for (const pathKey in spec.paths) {
+      for (const methodKey in spec.paths[pathKey]) {
+        const operation: OpenAPIV3.OperationObject = (spec.paths[pathKey] as any)[methodKey];
+        if (operation.tags) {
+          operation.tags.forEach((tag) => usedTags.add(tag));
+        }
+      }
+    }
+
+    spec.tags = spec.tags.filter((tagObj) => usedTags.has(tagObj.name));
+  }
+
+  private static removeUserDefinedRootProperty(spec: OpenAPIV3.Document): void {
+    for (const key in spec) {
+      if (key.startsWith("x-")) {
+        delete (spec as any)[key];
+      }
+    }
+  }
+
+  private static removeUnusedComponents(spec: OpenAPIV3.Document): void {
+    const components = spec.components;
+    if (!components) {
+      return;
+    }
+
+    delete spec.components;
+
+    const usedComponentsSet = new Set<string>();
+
+    const specString = JSON.stringify(spec);
+    const componentReferences = SpecOptimizer.getComponentReferences(specString);
+
+    for (const reference of componentReferences) {
+      this.addComponent(reference, usedComponentsSet, components);
+    }
+
+    const newComponents: any = {};
+
+    for (const componentName of usedComponentsSet) {
+      const parts = componentName.split("/");
+      const component = this.getComponent(componentName, components);
+      if (component) {
+        let current = newComponents;
+        for (let i = 2; i < parts.length; i++) {
+          if (i === parts.length - 1) {
+            current[parts[i]] = component;
+          } else if (!current[parts[i]]) {
+            current[parts[i]] = {};
+          }
+          current = current[parts[i]];
+        }
+      }
+    }
+
+    // securitySchemes are referenced directly by name, to void issue, just keep them all and use removeUnusedSecuritySchemas to remove unused ones
+    if (components.securitySchemes) {
+      newComponents.securitySchemes = components.securitySchemes;
+    }
+
+    if (Object.keys(newComponents).length !== 0) {
+      spec.components = newComponents;
+    }
+  }
+
+  private static getComponentReferences(specString: string): string[] {
+    const matches = Array.from(specString.matchAll(/['"](#\/components\/.+?)['"]/g));
+    const matchResult = matches.map((match) => match[1]);
+    return matchResult;
+  }
+
+  private static getComponent(componentPath: string, components: OpenAPIV3.ComponentsObject): any {
+    const parts = componentPath.split("/");
+    let current: any = components;
+
+    for (const part of parts) {
+      if (part === "#" || part === "components") {
+        continue;
+      }
+      current = current[part];
+      if (!current) {
+        return null;
+      }
+    }
+
+    return current;
+  }
+
+  private static addComponent(
+    componentName: string,
+    usedComponentsSet: Set<string>,
+    components: OpenAPIV3.ComponentsObject
+  ) {
+    if (usedComponentsSet.has(componentName)) {
+      return;
+    }
+    usedComponentsSet.add(componentName);
+
+    const component = this.getComponent(componentName, components);
+    if (component) {
+      const componentString = JSON.stringify(component);
+      const componentReferences = SpecOptimizer.getComponentReferences(componentString);
+      for (const reference of componentReferences) {
+        this.addComponent(reference, usedComponentsSet, components);
+      }
+    }
+  }
+}

--- a/packages/spec-parser/test/specOptimizer.test.ts
+++ b/packages/spec-parser/test/specOptimizer.test.ts
@@ -1,0 +1,629 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import "mocha";
+import sinon from "sinon";
+import { SpecOptimizer } from "../src/specOptimizer";
+
+describe("specOptimizer.test", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should remove unused components, unused tags, user defined root property, unused security", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      "x-user-defined": {
+        $ref: "#/components/schemas/Pet",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+        {
+          name: "pet",
+          description: "pet operations",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            security: [
+              {
+                api_key: [],
+              },
+            ],
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+          api_key2: {
+            type: "apiKey",
+            name: "api_key2",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Pet: {
+            type: "string",
+          },
+          Order: {
+            type: "string",
+          },
+        },
+        responses: {
+          "404NotFound": {
+            description: "The specified resource was not found.",
+          },
+        },
+      },
+    };
+
+    const expectedSpec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            operationId: "getUserById",
+            security: [
+              {
+                api_key: [],
+              },
+            ],
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any);
+    expect(result).to.deep.equal(expectedSpec);
+  });
+
+  it("should maintain original spec when optimization is disabled", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      "x-user-defined": {
+        $ref: "#/components/schemas/Pet",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+        {
+          name: "pet",
+          description: "pet operations",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            security: [
+              {
+                api_key: [],
+              },
+            ],
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+          api_key2: {
+            type: "apiKey",
+            name: "api_key2",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Pet: {
+            type: "string",
+          },
+          Order: {
+            type: "string",
+          },
+        },
+        responses: {
+          "404NotFound": {
+            description: "The specified resource was not found.",
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any, {
+      removeUnusedComponents: false,
+      removeUnusedTags: false,
+      removeUserDefinedRootProperty: false,
+      removeUnusedSecuritySchemas: false,
+    });
+    expect(result).to.deep.equal(spec);
+  });
+
+  it("should maintain original spec if no optimization can be performed", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+      ],
+
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            security: [
+              {
+                api_key: [],
+              },
+            ],
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any);
+    expect(result).to.deep.equal(spec);
+  });
+
+  it("should remove securitySchemes if it empty after optimization", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const expectedSpec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      tags: [
+        {
+          name: "user",
+          description: "user operations",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            tags: ["user"],
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any);
+    expect(result).to.deep.equal(expectedSpec);
+  });
+
+  it("should remove components if it empty after optimization", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const expectedSpec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any);
+    expect(result).to.deep.equal(expectedSpec);
+  });
+});

--- a/packages/spec-parser/test/specOptimizer.test.ts
+++ b/packages/spec-parser/test/specOptimizer.test.ts
@@ -36,6 +36,11 @@ describe("specOptimizer.test", () => {
           description: "pet operations",
         },
       ],
+      security: [
+        {
+          api_key2: [],
+        },
+      ],
       paths: {
         "/user/{userId}": {
           get: {
@@ -70,6 +75,33 @@ describe("specOptimizer.test", () => {
             },
           },
         },
+        "/user/{name}": {
+          get: {
+            operationId: "getUserByName",
+            parameters: [
+              {
+                name: "name",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         securitySchemes: {
@@ -81,6 +113,11 @@ describe("specOptimizer.test", () => {
           api_key2: {
             type: "apiKey",
             name: "api_key2",
+            in: "header",
+          },
+          api_key3: {
+            type: "apiKey",
+            name: "api_key3",
             in: "header",
           },
         },
@@ -125,6 +162,11 @@ describe("specOptimizer.test", () => {
           description: "user operations",
         },
       ],
+      security: [
+        {
+          api_key2: [],
+        },
+      ],
       paths: {
         "/user/{userId}": {
           get: {
@@ -159,12 +201,44 @@ describe("specOptimizer.test", () => {
             },
           },
         },
+        "/user/{name}": {
+          get: {
+            operationId: "getUserByName",
+            parameters: [
+              {
+                name: "name",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         securitySchemes: {
           api_key: {
             type: "apiKey",
             name: "api_key",
+            in: "header",
+          },
+          api_key2: {
+            type: "apiKey",
+            name: "api_key2",
             in: "header",
           },
         },
@@ -312,7 +386,6 @@ describe("specOptimizer.test", () => {
           description: "user operations",
         },
       ],
-
       paths: {
         "/user/{userId}": {
           get: {
@@ -388,16 +461,9 @@ describe("specOptimizer.test", () => {
           url: "https://server1",
         },
       ],
-      tags: [
-        {
-          name: "user",
-          description: "user operations",
-        },
-      ],
       paths: {
         "/user/{userId}": {
           get: {
-            tags: ["user"],
             operationId: "getUserById",
             parameters: [
               {
@@ -459,16 +525,9 @@ describe("specOptimizer.test", () => {
           url: "https://server1",
         },
       ],
-      tags: [
-        {
-          name: "user",
-          description: "user operations",
-        },
-      ],
       paths: {
         "/user/{userId}": {
           get: {
-            tags: ["user"],
             operationId: "getUserById",
             parameters: [
               {
@@ -596,6 +655,119 @@ describe("specOptimizer.test", () => {
         "/user/{userId}": {
           get: {
             operationId: "getUserById",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = SpecOptimizer.optimize(spec as any);
+    expect(result).to.deep.equal(expectedSpec);
+  });
+
+  it("should works fine if matches unexpected component reference", () => {
+    const spec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            operationId: "getUserById",
+            description: "#/components/schemas/Unexpected/Reference/Pattern",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                required: true,
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "test",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: "apiKey",
+            name: "api_key",
+            in: "header",
+          },
+        },
+        schemas: {
+          User: {
+            type: "object",
+            properties: {
+              order: {
+                $ref: "#/components/schemas/Order",
+              },
+            },
+          },
+          Order: {
+            type: "string",
+          },
+        },
+      },
+    };
+
+    const expectedSpec = {
+      openapi: "3.0.2",
+      info: {
+        title: "User Service",
+        version: "1.0.0",
+      },
+      servers: [
+        {
+          url: "https://server1",
+        },
+      ],
+      paths: {
+        "/user/{userId}": {
+          get: {
+            operationId: "getUserById",
+            description: "#/components/schemas/Unexpected/Reference/Pattern",
             parameters: [
               {
                 name: "userId",


### PR DESCRIPTION
Original file [Github API OpenAPI spec file](https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml): 7.77M

Testing select 7 search API with/without optimization:
![image](https://github.com/OfficeDev/teams-toolkit/assets/5545529/0d7df8de-b075-4dd7-95ca-5cdc2309dffb)

without optimization:  7.09M 
[openapi.yaml.txt](https://github.com/user-attachments/files/15922005/openapi.yaml.txt)


with optimization:  126K
[openapi.yaml.txt](https://github.com/user-attachments/files/15922032/openapi.yaml.txt)

