### PR TITLE
fix: remove auto install dependency window

### DIFF
--- a/packages/vscode-extension/src/officeDevHandlers.ts
+++ b/packages/vscode-extension/src/officeDevHandlers.ts
@@ -236,14 +236,7 @@ export async function autoOpenOfficeDevProjectHandler(): Promise<void> {
     await globalStateUpdate(GlobalKey.OpenSampleReadMe, false);
   }
   if (autoInstallDependency) {
-    void popupOfficeAddInDependenciesMessage();
     await globalStateUpdate(GlobalKey.AutoInstallDependency, false);
-  }
-  if (
-    globalVariables.isOfficeAddInProject &&
-    !checkOfficeAddInInstalled(globalVariables.workspaceUri?.fsPath ?? "")
-  ) {
-    void popupOfficeAddInDependenciesMessage();
   }
 }
 


### PR DESCRIPTION
Removed auto install dependency pop-up window when open an Office add-in project using TTK.