### PR TITLE
fix: not show the changelog prompt on a fresh install

### DIFF
--- a/packages/vscode-extension/src/utils/releaseNote.ts
+++ b/packages/vscode-extension/src/utils/releaseNote.ts
@@ -39,17 +39,14 @@ export class ReleaseNote {
       }
     } else {
       const currentStableVersion = this.context.globalState.get<string>(SyncedState.Version);
+      await this.context.globalState.update(SyncedState.Version, teamsToolkitVersion);
       if (
-        currentStableVersion === undefined ||
+        currentStableVersion !== undefined &&
         versionUtil.compare(teamsToolkitVersion, currentStableVersion) === 1
       ) {
-        // if syncedVersion is undefined, then it is not existinig user
-        await this.context.globalState.update(
-          UserState.IsExisting,
-          currentStableVersion === undefined ? "no" : "yes"
-        );
+        // it is existinig user
+        await this.context.globalState.update(UserState.IsExisting, "yes");
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ShowWhatIsNewNotification);
-        await this.context.globalState.update(SyncedState.Version, teamsToolkitVersion);
 
         const changelog = {
           title: localize("teamstoolkit.upgrade.changelog"),

--- a/packages/vscode-extension/test/utils/releaseNote.test.ts
+++ b/packages/vscode-extension/test/utils/releaseNote.test.ts
@@ -98,7 +98,16 @@ describe("Release Note", () => {
       sandbox.stub(vscode.window, "showInformationMessage").resolves();
       const instance = new ReleaseNote(context);
       await instance.show();
-      sinon.assert.notCalled(contextSpy);
+      sinon.assert.calledOnce(contextSpy);
+      chai.assert(telemetryStub.notCalled);
+    });
+    it("should not show changelog when it's a fresh install", async () => {
+      const contextSpy = sandbox.spy(context.globalState, "update");
+      sandbox.stub(context.globalState, "get").returns(undefined);
+      sandbox.stub(vscode.window, "showInformationMessage").resolves();
+      const instance = new ReleaseNote(context);
+      await instance.show();
+      sinon.assert.calledOnce(contextSpy);
       chai.assert(telemetryStub.notCalled);
     });
   });


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28574492