### PR TITLE
feat: show diagnostics

### DIFF
--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -405,6 +405,11 @@ export interface UserInteraction {
   selectFileOrInput?(
     config: SingleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>>;
+
+  /**
+   * Supports in VSC only for now. Show diagnostic message in editor.
+   */
+  showDiagnosticMessage?(): Promise<Result<string, FxError>>;
 }
 
 export interface IProgressHandler {

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -409,7 +409,7 @@ export interface UserInteraction {
   /**
    * Supports in VSC only for now. Show diagnostic message in editor.
    */
-  showDiagnosticMessage?(): Promise<Result<string, FxError>>;
+  showDiagnosticInfo?(diagnostics: IDiagnosticInfo[]): void;
 }
 
 export interface IProgressHandler {
@@ -433,4 +433,71 @@ export interface IProgressHandler {
    * can be reused after calling end().
    */
   end: (success: boolean, hideAfterFinish?: boolean) => Promise<void>;
+}
+
+export enum DiagnosticSeverity {
+  /**
+   * Something not allowed by the rules of a language or other means.
+   */
+  Error = 0,
+
+  /**
+   * Something suspicious but allowed.
+   */
+  Warning = 1,
+
+  /**
+   * Something to inform about but not a problem.
+   */
+  Information = 2,
+
+  /**
+   * Something to hint to a better way of doing it, like proposing
+   * a refactoring.
+   */
+  Hint = 3,
+}
+
+export interface IDiagnosticInfo {
+  /**
+   * Path of file where diagnostic shows.
+   */
+  filePath: string;
+  /**
+   * Line number where diagnostic info starts.
+   */
+  startLine: number;
+  /**
+   * Index of the beginning character where diagnostic info shows
+   */
+  startIndex: number;
+  /**
+   * Line number where diagnostic info ends.
+   */
+  endLine: number;
+  /**
+   * Index of the end character where diagnostic info ends.
+   */
+  endIndex: number;
+  /**
+   * Message.
+   */
+  message: string;
+  /**
+   * Severity.
+   */
+  severity: DiagnosticSeverity;
+  /**
+   * A code or identifier for this diagnostic.
+   */
+  code?: {
+    /**
+     * Value.
+     */
+    value: string;
+    /**
+     * Link to open with more information about the diagnostic error.
+     */
+    link: string;
+  };
 }

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -52,6 +52,7 @@ export class FeatureFlagName {
   static readonly NewGenerator = "TEAMSFX_NEW_GENERATOR";
   static readonly SMEOAuth = "SME_OAUTH";
   static readonly CustomizeGpt = "TEAMSFX_DECLARATIVE_COPILOT";
+  static readonly ShowDiagnostics = "TEAMSFX_SHOW_DIAGNOSTICS";
 }
 
 export function getAllowedAppMaps(): Record<string, string> {

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -94,6 +94,10 @@ export class FeatureFlags {
   };
   static readonly SMEOAuth = { name: FeatureFlagName.SMEOAuth, defaultValue: "false" };
   static readonly CustomizeGpt = { name: FeatureFlagName.CustomizeGpt, defaultValue: "false" };
+  static readonly ShowDiagnostics = {
+    name: FeatureFlagName.ShowDiagnostics,
+    defaultValue: "false",
+  };
 }
 
 export class FeatureFlagManager {

--- a/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
@@ -14,6 +14,7 @@ import {
   Platform,
   Result,
   TeamsAppManifest,
+  UserInteraction,
   err,
   ok,
 } from "@microsoft/teamsfx-api";
@@ -210,6 +211,13 @@ export class ValidateAppPackageDriver implements StepDriver {
         }
       } else {
         // logs in output window
+        if (context && context.ui) {
+          const diaMessage = await context.ui.showDiagnosticMessage!();
+          if (diaMessage.isErr()) {
+            context.logProvider?.error(diaMessage.error.message);
+          }
+        }
+
         const errors = validationResult.errors
           .map((error) => {
             let message = `${SummaryConstant.Failed} ${error.content} \n${getLocalizedString(

--- a/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
@@ -14,7 +14,6 @@ import {
   Platform,
   Result,
   TeamsAppManifest,
-  UserInteraction,
   err,
   ok,
 } from "@microsoft/teamsfx-api";
@@ -303,9 +302,6 @@ export class ValidateAppPackageDriver implements StepDriver {
           "driver.teamsApp.validate.result.display",
           summaryStr.join(", ")
         );
-        if (context.platform === Platform.VSCode && errors.length > 0) {
-          context.ui?.showDiagnosticInfo!([]);
-        }
         if (args.showMessage) {
           // For non-lifecycle commands, just show the message
           if (validationResult.errors.length > 0) {

--- a/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
@@ -211,13 +211,6 @@ export class ValidateAppPackageDriver implements StepDriver {
         }
       } else {
         // logs in output window
-        if (context && context.ui) {
-          const diaMessage = await context.ui.showDiagnosticMessage!();
-          if (diaMessage.isErr()) {
-            context.logProvider?.error(diaMessage.error.message);
-          }
-        }
-
         const errors = validationResult.errors
           .map((error) => {
             let message = `${SummaryConstant.Failed} ${error.content} \n${getLocalizedString(
@@ -310,6 +303,9 @@ export class ValidateAppPackageDriver implements StepDriver {
           "driver.teamsApp.validate.result.display",
           summaryStr.join(", ")
         );
+        if (context.platform === Platform.VSCode && errors.length > 0) {
+          context.ui?.showDiagnosticInfo!([]);
+        }
         if (args.showMessage) {
           // For non-lifecycle commands, just show the message
           if (validationResult.errors.length > 0) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -177,7 +177,7 @@ import {
   handleOfficeFeedback,
   officeChatRequestHandler,
 } from "./officeChat/handlers";
-import { VsCodeUI, initVSCodeUI } from "./qm/vsc_ui";
+import { initVSCodeUI } from "./qm/vsc_ui";
 import { ExtTelemetry } from "./telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryTriggerFrom } from "./telemetry/extTelemetryEvents";
 import accountTreeViewProviderInstance from "./treeview/account/accountTreeViewProvider";
@@ -207,7 +207,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   initVSCodeUI(context);
   initializeGlobalVariables(context);
-
   loadLocalizedStrings();
 
   const uriHandler = new UriHandler();

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -270,13 +270,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   void VsCodeLogInstance.info("Teams Toolkit extension is now active!");
 
-  vscode.workspace.onDidSaveTextDocument(async (event) => {
-    if (event.fileName.includes("manifest.json")) {
-      const tt = new VsCodeUI(context);
-      await tt.showDiagnosticMessage();
-    }
-  });
-
   // Don't wait this async method to let it run in background.
   void runBackgroundAsyncTasks(context, isTeamsFxProject);
   await vscode.commands.executeCommand("setContext", "fx-extension.initialized", true);

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -28,7 +28,7 @@ export let defaultExtensionLogPath: string;
 export let commandIsRunning = false;
 export let core: FxCore;
 export let tools: Tools;
-export let diagnosticCollection: vscode.DiagnosticCollection;
+export let diagnosticCollection: vscode.DiagnosticCollection; // Collection of diagnositcs after running app validation.
 
 if (vscode.workspace && vscode.workspace.workspaceFolders) {
   if (vscode.workspace.workspaceFolders.length > 0) {

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -56,10 +56,6 @@ export function initializeGlobalVariables(ctx: vscode.ExtensionContext): void {
   } else {
     isSPFxProject = fs.existsSync(path.join(workspaceUri?.fsPath ?? "./", "SPFx"));
   }
-
-  if (!diagnosticCollection) {
-    diagnosticCollection = vscode.languages.createDiagnosticCollection("teamstoolkit");
-  }
 }
 
 export function checkIsSPFx(directory: string): boolean {
@@ -91,4 +87,8 @@ export function setTools(toolsInstance: Tools) {
 }
 export function setCore(coreInstance: FxCore) {
   core = coreInstance;
+}
+
+export function setDiagnosticCollection(collection: vscode.DiagnosticCollection) {
+  diagnosticCollection = collection;
 }

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -28,6 +28,7 @@ export let defaultExtensionLogPath: string;
 export let commandIsRunning = false;
 export let core: FxCore;
 export let tools: Tools;
+export let diagnosticCollection: vscode.DiagnosticCollection;
 
 if (vscode.workspace && vscode.workspace.workspaceFolders) {
   if (vscode.workspace.workspaceFolders.length > 0) {
@@ -54,6 +55,10 @@ export function initializeGlobalVariables(ctx: vscode.ExtensionContext): void {
     isSPFxProject = checkIsSPFx(workspaceUri?.fsPath);
   } else {
     isSPFxProject = fs.existsSync(path.join(workspaceUri?.fsPath ?? "./", "SPFx"));
+  }
+
+  if (!diagnosticCollection) {
+    diagnosticCollection = vscode.languages.createDiagnosticCollection("teamstoolkit");
   }
 }
 

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -10,11 +10,13 @@ import {
   Uri,
   Range,
   Position,
+  languages,
 } from "vscode";
 
 import {
   err,
   FxError,
+  IDiagnosticInfo,
   InputResult,
   ok,
   Result,
@@ -148,69 +150,95 @@ export class VsCodeUI extends VSCodeUI {
     return res;
   }
 
-  async showDiagnosticMessage(): Promise<Result<string, FxError>> {
-    // if(!diagnosticCollection) {
-
-    // }
-    await sleep(1000);
+  showDiagnosticInfo(diagnostics: IDiagnosticInfo[]): void {
     diagnosticCollection.clear();
-    const errors = [
-      {
-        id: "958d86ff-864b-474d-bea4-d8068b8c8cad",
-        title: "ShortNameContainsPreprodWording",
-        content: "Short name doesn't contain beta environment keywords",
-        helpUrl:
-          "https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#name",
-        filePath: "manifest.json",
-        shortCodeNumber: 4000,
-        validationCategory: "Name",
-      },
-    ];
-
     const diagnosticMap: Map<string, Diagnostic[]> = new Map();
-    errors.forEach((error) => {
-      const canonicalFile = "manifest.json";
-      const regex = new RegExp(error.validationCategory);
-
-      // const text = document.getText();
-
-      // const line = document.lineAt(document.positionAt(matches.index).line);
-      // const indexOf = line.text.indexOf(match);
-      // const position = new Position(line.lineNumber, indexOf);
-      const range = new Range(new Position(6, 2), new Position(6, 6));
-
-      let diagnostics = diagnosticMap.get(canonicalFile);
-      if (!diagnostics) {
-        diagnostics = [];
+    for (const diagnostic of diagnostics) {
+      let diagnosticsOfFile = diagnosticMap.get(diagnostic.filePath);
+      if (!diagnosticsOfFile) {
+        diagnosticsOfFile = [];
+        diagnosticMap.set(diagnostic.filePath, diagnosticsOfFile);
       }
 
-      //const message = `[✏️Edit env file](${commandUri.toString()})`;
-      const diag = new Diagnostic(
-        range,
-        "Short name doesn't contain beta environment keywords",
-        DiagnosticSeverity.Warning
-      );
-      diag.code = {
-        value: "NameField",
-        target: Uri.parse(
-          "https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#name"
+      const diagnosticInVSC = new Diagnostic(
+        new Range(
+          new Position(diagnostic.startLine, diagnostic.startIndex),
+          new Position(diagnostic.endLine, diagnostic.endIndex)
         ),
-      };
-      diag.source = "TTK";
-
-      diagnostics.push(diag);
-      diagnosticMap.set(canonicalFile, diagnostics);
-
-      const fileUri = Uri.file(
-        path.join(workspaceUri?.fsPath?.toString() ?? "", "appPackage", "manifest.json")
+        diagnostic.message,
+        diagnostic.severity
       );
-      console.log(fileUri);
-      diagnosticMap.forEach((diags, file) => {
-        diagnosticCollection.set(fileUri, diags);
-      });
+      if (diagnostic.code) {
+        diagnosticInVSC.code = {
+          value: diagnostic.code.value,
+          target: Uri.parse(diagnostic.code.link),
+        };
+      }
+      diagnosticsOfFile.push(diagnosticInVSC);
+    }
+    diagnosticMap.forEach((diags, filePath) => {
+      diagnosticCollection.set(Uri.file(filePath), diags);
     });
 
-    return ok("donevsc");
+    // diagnosticCollection.clear();
+    // const errors = [
+    //   {
+    //     id: "958d86ff-864b-474d-bea4-d8068b8c8cad",
+    //     title: "ShortNameContainsPreprodWording",
+    //     content: "Short name doesn't contain beta environment keywords",
+    //     helpUrl:
+    //       "https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#name",
+    //     filePath: "manifest.json",
+    //     shortCodeNumber: 4000,
+    //     validationCategory: "Name",
+    //   },
+    // ];
+
+    // const collection2 = languages.createDiagnosticCollection("teamstoolkit2");
+
+    // const diagnosticMap: Map<string, Diagnostic[]> = new Map();
+    // errors.forEach((error) => {
+    //   const canonicalFile = "manifest.json";
+    //   const regex = new RegExp(error.validationCategory);
+
+    //   // const text = document.getText();
+
+    //   // const line = document.lineAt(document.positionAt(matches.index).line);
+    //   // const indexOf = line.text.indexOf(match);
+    //   // const position = new Position(line.lineNumber, indexOf);
+    //   const range = new Range(new Position(6, 2), new Position(6, 6));
+
+    //   let diagnostics = diagnosticMap.get(canonicalFile);
+    //   if (!diagnostics) {
+    //     diagnostics = [];
+    //   }
+
+    //   //const message = `[✏️Edit env file](${commandUri.toString()})`;
+    //   const diag = new Diagnostic(
+    //     range,
+    //     "Short name doesn't contain beta environment keywords",
+    //     DiagnosticSeverity.Warning
+    //   );
+    //   diag.code = {
+    //     value: "NameField",
+    //     target: Uri.parse(
+    //       "https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#name"
+    //     ),
+    //   };
+    //   diag.source = "TTK";
+
+    //   diagnostics.push(diag);
+    //   diagnosticMap.set(canonicalFile, diagnostics);
+
+    //   const fileUri = Uri.file(
+    //     path.join(workspaceUri?.fsPath?.toString() ?? "", "appPackage", "manifest.json")
+    //   );
+    //   console.log(fileUri);
+    //   diagnosticMap.forEach((diags, file) => {
+    //     diagnosticCollection.set(fileUri, diags);
+    //     collection2.set(fileUri, diags);
+    //   });
+    // });
   }
 }
 

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -202,8 +202,9 @@ export class VsCodeUI extends VSCodeUI {
       diagnosticMap.set(canonicalFile, diagnostics);
 
       const fileUri = Uri.file(
-        path.join(workspaceUri?.toString() ?? "", "appPackage", "manifest.json")
+        path.join(workspaceUri?.fsPath?.toString() ?? "", "appPackage", "manifest.json")
       );
+      console.log(fileUri);
       diagnosticMap.forEach((diags, file) => {
         diagnosticCollection.set(fileUri, diags);
       });

--- a/packages/vscode-extension/test/mocks/vscode-mock.ts
+++ b/packages/vscode-extension/test/mocks/vscode-mock.ts
@@ -27,7 +27,7 @@ class MockClipboard {
 }
 
 export function initialize() {
-  generateMock("languages");
+  //generateMock("languages");
   generateMock("debug");
   generateMock("scm");
   generateNotebookMocks();
@@ -193,6 +193,12 @@ mockedVSCode.extensions = {
     });
   },
   all: [],
+};
+
+(mockedVSCode as any).languages = {
+  createDiagnosticCollection: () => {},
+  registerCodeLensProvider: () => {},
+  registerHoverProvider: () => {},
 };
 
 // Setup commands APIs

--- a/packages/vscode-extension/test/mocks/vscode-mock.ts
+++ b/packages/vscode-extension/test/mocks/vscode-mock.ts
@@ -27,7 +27,6 @@ class MockClipboard {
 }
 
 export function initialize() {
-  //generateMock("languages");
   generateMock("debug");
   generateMock("scm");
   generateNotebookMocks();

--- a/packages/vscode-extension/test/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/qm/vsc_ui.test.ts
@@ -999,7 +999,7 @@ describe("UI Unit Tests", async () => {
         },
       } as unknown as DiagnosticCollection;
 
-      sandbox.stub(languages, "createDiagnosticCollection").returns(collection as any);
+      globalVariables.setDiagnosticCollection(collection);
       const ui = new VsCodeUI(<ExtensionContext>{});
 
       ui.showDiagnosticInfo([

--- a/packages/vscode-extension/test/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/qm/vsc_ui.test.ts
@@ -7,8 +7,10 @@ import * as sinon from "sinon";
 import { stubInterface } from "ts-sinon";
 import {
   commands,
+  DiagnosticCollection,
   Disposable,
   ExtensionContext,
+  languages,
   QuickInputButton,
   QuickPick,
   Terminal,
@@ -30,6 +32,8 @@ import { FxQuickPickItem, sleep, UserCancelError } from "@microsoft/vscode-ui";
 import { VsCodeUI } from "../../src/qm/vsc_ui";
 import { ExtTelemetry } from "../../src/telemetry/extTelemetry";
 import { VsCodeLogProvider } from "../../src/commonlib/log";
+import { featureFlagManager } from "@microsoft/teamsfx-core";
+import * as globalVariables from "../../src/globalVariables";
 
 describe("UI Unit Tests", async () => {
   afterEach(() => {
@@ -937,6 +941,85 @@ describe("UI Unit Tests", async () => {
       if (result.isOk()) {
         expect(result.value.result).to.equal("testUrl");
       }
+    });
+  });
+
+  describe("showDiagnosticInfo", () => {
+    const sandbox = sinon.createSandbox();
+    let collection: DiagnosticCollection | undefined;
+
+    afterEach(() => {
+      sandbox.restore();
+      globalVariables.setDiagnosticCollection(undefined as unknown as DiagnosticCollection);
+    });
+
+    it("do nothing if feature flag is disabled", () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      ui.showDiagnosticInfo([]);
+    });
+
+    it("show diagnostics first time if feature flag is enabled", () => {
+      const records: [string, { message: string }][] = [];
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+      collection = {
+        set: (filePath: string, diag: { message: string }) => {
+          records.push([filePath, diag]);
+        },
+      } as unknown as DiagnosticCollection;
+
+      sandbox.stub(languages, "createDiagnosticCollection").returns(collection as any);
+      const ui = new VsCodeUI(<ExtensionContext>{});
+
+      ui.showDiagnosticInfo([
+        {
+          startIndex: 0,
+          startLine: 1,
+          endIndex: 10,
+          endLine: 10,
+          severity: 2,
+          filePath: "test",
+          message: "error",
+        },
+      ]);
+
+      expect(globalVariables.diagnosticCollection).not.undefined;
+      expect(records.length).equals(1);
+    });
+
+    it("show diagnostics not first time if feature flag is enabled", () => {
+      const records: [string, { message: string }][] = [];
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+      collection = {
+        clear: () => {
+          return;
+        },
+        set: (filePath: string, diag: { message: string }) => {
+          records.push([filePath, diag]);
+        },
+      } as unknown as DiagnosticCollection;
+
+      sandbox.stub(languages, "createDiagnosticCollection").returns(collection as any);
+      const ui = new VsCodeUI(<ExtensionContext>{});
+
+      ui.showDiagnosticInfo([
+        {
+          startIndex: 0,
+          startLine: 1,
+          endIndex: 10,
+          endLine: 10,
+          severity: 2,
+          filePath: "test",
+          message: "error",
+          code: {
+            value: "test",
+            link: "https://test.com",
+          },
+        },
+      ]);
+
+      expect(globalVariables.diagnosticCollection).not.undefined;
+      expect(records.length).equals(1);
     });
   });
 });


### PR DESCRIPTION
- add API to show diagnostics in editor. We are going to show validation errors as diagnostics later.
[Feature 28307640](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28307640): [PartnerFeatureAsk] Custom validation rules display in the editor for apps and plugins