### PR TITLE
refactor: update API Key label to include Bearer Token Auth

### DIFF
--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -815,7 +815,7 @@ export class ApiAuthOptions {
   static apiKey(): OptionItem {
     return {
       id: "api-key",
-      label: "API Key",
+      label: "API Key (Bearer Token Auth)",
     };
   }
 


### PR DESCRIPTION
Update the API key authentication option to help make things a bit clearer.
![image](https://github.com/OfficeDev/teams-toolkit/assets/107838226/4d8a3a61-a6c4-4cad-94d5-4720f23ef63e)
