### PR TITLE
test: remove invalid link from migration assets

### DIFF
--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/.fx/configs/config.dev.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/.fx/configs/config.dev.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://aka.ms/teamsfx-env-config-schema",
-    "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-env-config to learn more about this.",
     "manifest": {
         "appName": {
             "short": "testApp",

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/.fx/configs/config.local.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/.fx/configs/config.local.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://aka.ms/teamsfx-env-config-schema",
-    "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-env-config to learn more about this.",
     "manifest": {
         "appName": {
             "short": "testApp-local",


### PR DESCRIPTION
remove https://aka.ms/teamsfx-env-config since this link is invalid