### PR TITLE
fix: add icon

### DIFF
--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1010,7 +1010,7 @@ export function apiSpecLocationQuestion(includeExistingAPIs = true): SingleFileO
     },
     inputOptionItem: {
       id: "input",
-      label: getLocalizedString("core.createProjectQuestion.apiSpecInputUrl.label"),
+      label: `$(cloud) ` + getLocalizedString("core.createProjectQuestion.apiSpecInputUrl.label"),
     },
     filters: {
       files: ["json", "yml", "yaml"],


### PR DESCRIPTION
Add icon. This item will only be used in VSC.
![image](https://github.com/OfficeDev/teams-toolkit/assets/86260893/6665a8e7-2a6e-4666-9426-2d7775639c5c)


[Bug 28665783](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28665783): Missing icon for "Enter OpenAPI Description Document"

