### PR TITLE
feat: add desktop launch option for python custom-copilot templates

### DIFF
--- a/templates/python/custom-copilot-assistant-assistants-api/.vscode/launch.json
+++ b/templates/python/custom-copilot-assistant-assistants-api/.vscode/launch.json
@@ -2,26 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote in Teams (Edge)",
+            "name": "Launch Remote (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Remote in Teams (Chrome)",
+            "name": "Launch Remote (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 2
             },
             "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "3-remote",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen",
         },
         {
             "name": "Launch App (Edge)",
@@ -86,6 +97,18 @@
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Teams (Desktop)",
+            "configurations": [
+                "Start Python"
+            ],
+            "preLaunchTask": "Start Teams App in Desktop Client",
+            "presentation": {
+                "group": "1-local",
+                "order": 3
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/python/custom-copilot-assistant-assistants-api/.vscode/tasks.json
+++ b/templates/python/custom-copilot-assistant-assistants-api/.vscode/tasks.json
@@ -81,7 +81,6 @@
                 "Start local tunnel",
                 "Provision",
                 "Deploy",
-                "Start application",
                 "Start desktop client"
             ],
             "dependsOrder": "sequence"

--- a/templates/python/custom-copilot-assistant-assistants-api/.vscode/tasks.json
+++ b/templates/python/custom-copilot-assistant-assistants-api/.vscode/tasks.json
@@ -73,6 +73,34 @@
             "args": {
                 "env": "local"
             }
+        },
+        {
+            "label": "Start Teams App in Desktop Client",
+            "dependsOn": [
+                "Validate prerequisites",
+                "Start local tunnel",
+                "Provision",
+                "Deploy",
+                "Start application",
+                "Start desktop client"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Start desktop client",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true"
+            }
+        },
+        {
+            "label": "Start Teams App in Desktop Client (Remote)",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true"
+            }
         }
     ]
 }

--- a/templates/python/custom-copilot-assistant-new/.vscode/launch.json
+++ b/templates/python/custom-copilot-assistant-new/.vscode/launch.json
@@ -2,26 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote in Teams (Edge)",
+            "name": "Launch Remote (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Remote in Teams (Chrome)",
+            "name": "Launch Remote (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 2
             },
             "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "3-remote",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen",
         },
         {
             "name": "Launch App (Edge)",
@@ -86,6 +97,18 @@
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Teams (Desktop)",
+            "configurations": [
+                "Start Python"
+            ],
+            "preLaunchTask": "Start Teams App in Desktop Client",
+            "presentation": {
+                "group": "1-local",
+                "order": 3
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/python/custom-copilot-assistant-new/.vscode/tasks.json
+++ b/templates/python/custom-copilot-assistant-new/.vscode/tasks.json
@@ -81,7 +81,6 @@
                 "Start local tunnel",
                 "Provision",
                 "Deploy",
-                "Start application",
                 "Start desktop client"
             ],
             "dependsOrder": "sequence"

--- a/templates/python/custom-copilot-assistant-new/.vscode/tasks.json
+++ b/templates/python/custom-copilot-assistant-new/.vscode/tasks.json
@@ -73,6 +73,34 @@
             "args": {
                 "env": "local"
             }
+        },
+        {
+            "label": "Start Teams App in Desktop Client",
+            "dependsOn": [
+                "Validate prerequisites",
+                "Start local tunnel",
+                "Provision",
+                "Deploy",
+                "Start application",
+                "Start desktop client"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Start desktop client",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true"
+            }
+        },
+        {
+            "label": "Start Teams App in Desktop Client (Remote)",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true"
+            }
         }
     ]
 }

--- a/templates/python/custom-copilot-basic/.vscode/launch.json
+++ b/templates/python/custom-copilot-basic/.vscode/launch.json
@@ -2,26 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote in Teams (Edge)",
+            "name": "Launch Remote (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Remote in Teams (Chrome)",
+            "name": "Launch Remote (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 2
             },
             "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "3-remote",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen",
         },
         {
             "name": "Launch App (Edge)",
@@ -86,6 +97,18 @@
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Teams (Desktop)",
+            "configurations": [
+                "Start Python"
+            ],
+            "preLaunchTask": "Start Teams App in Desktop Client",
+            "presentation": {
+                "group": "1-local",
+                "order": 3
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/python/custom-copilot-basic/.vscode/tasks.json
+++ b/templates/python/custom-copilot-basic/.vscode/tasks.json
@@ -81,7 +81,6 @@
                 "Start local tunnel",
                 "Provision",
                 "Deploy",
-                "Start application",
                 "Start desktop client"
             ],
             "dependsOrder": "sequence"

--- a/templates/python/custom-copilot-basic/.vscode/tasks.json
+++ b/templates/python/custom-copilot-basic/.vscode/tasks.json
@@ -73,6 +73,34 @@
             "args": {
                 "env": "local"
             }
+        },
+        {
+            "label": "Start Teams App in Desktop Client",
+            "dependsOn": [
+                "Validate prerequisites",
+                "Start local tunnel",
+                "Provision",
+                "Deploy",
+                "Start application",
+                "Start desktop client"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Start desktop client",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true"
+            }
+        },
+        {
+            "label": "Start Teams App in Desktop Client (Remote)",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true"
+            }
         }
     ]
 }

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json
@@ -2,26 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote in Teams (Edge)",
+            "name": "Launch Remote (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Remote in Teams (Chrome)",
+            "name": "Launch Remote (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 2
             },
             "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "3-remote",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen",
         },
         {
             "name": "Launch App (Edge)",
@@ -86,6 +97,18 @@
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Teams (Desktop)",
+            "configurations": [
+                "Start Python"
+            ],
+            "preLaunchTask": "Start Teams App in Desktop Client",
+            "presentation": {
+                "group": "1-local",
+                "order": 3
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/tasks.json
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/tasks.json
@@ -81,7 +81,6 @@
                 "Start local tunnel",
                 "Provision",
                 "Deploy",
-                "Start application",
                 "Start desktop client"
             ],
             "dependsOrder": "sequence"

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/tasks.json
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/tasks.json
@@ -73,6 +73,34 @@
             "args": {
                 "env": "local"
             }
+        },
+        {
+            "label": "Start Teams App in Desktop Client",
+            "dependsOn": [
+                "Validate prerequisites",
+                "Start local tunnel",
+                "Provision",
+                "Deploy",
+                "Start application",
+                "Start desktop client"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Start desktop client",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true"
+            }
+        },
+        {
+            "label": "Start Teams App in Desktop Client (Remote)",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true"
+            }
         }
     ]
 }

--- a/templates/python/custom-copilot-rag-customize/.vscode/launch.json
+++ b/templates/python/custom-copilot-rag-customize/.vscode/launch.json
@@ -2,26 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote in Teams (Edge)",
+            "name": "Launch Remote (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Remote in Teams (Chrome)",
+            "name": "Launch Remote (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "group 1: Teams",
-                "order": 3
+                "group": "3-remote",
+                "order": 2
             },
             "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "3-remote",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen",
         },
         {
             "name": "Launch App (Edge)",
@@ -48,8 +59,8 @@
         {
             "name": "Start Python",
             "type": "debugpy",
-            "program": "${workspaceFolder}/src/app.py",
             "request": "launch",
+            "program": "${workspaceFolder}/src/app.py",
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal"
         }
@@ -86,6 +97,18 @@
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Teams (Desktop)",
+            "configurations": [
+                "Start Python"
+            ],
+            "preLaunchTask": "Start Teams App in Desktop Client",
+            "presentation": {
+                "group": "1-local",
+                "order": 3
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/python/custom-copilot-rag-customize/.vscode/tasks.json
+++ b/templates/python/custom-copilot-rag-customize/.vscode/tasks.json
@@ -81,7 +81,6 @@
                 "Start local tunnel",
                 "Provision",
                 "Deploy",
-                "Start application",
                 "Start desktop client"
             ],
             "dependsOrder": "sequence"

--- a/templates/python/custom-copilot-rag-customize/.vscode/tasks.json
+++ b/templates/python/custom-copilot-rag-customize/.vscode/tasks.json
@@ -73,6 +73,34 @@
             "args": {
                 "env": "local"
             }
+        },
+        {
+            "label": "Start Teams App in Desktop Client",
+            "dependsOn": [
+                "Validate prerequisites",
+                "Start local tunnel",
+                "Provision",
+                "Deploy",
+                "Start application",
+                "Start desktop client"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Start desktop client",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true"
+            }
+        },
+        {
+            "label": "Start Teams App in Desktop Client (Remote)",
+            "type": "teamsfx",
+            "command": "launch-desktop-client",
+            "args": {
+                "url": "teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true"
+            }
         }
     ]
 }


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28711326