### PR TITLE
fix: wrong capabilities if .NET flag is enabled

### DIFF
--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -475,7 +475,7 @@ export class CapabilityOptions {
     };
   }
   static bots(inputs?: Inputs): OptionItem[] {
-    if (inputs?.platform === Platform.VS) {
+    if (inputs?.runtime === RuntimeOptions.DotNet().id) {
       return [
         CapabilityOptions.basicBot(),
         CapabilityOptions.aiBot(),

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -475,7 +475,7 @@ export class CapabilityOptions {
     };
   }
   static bots(inputs?: Inputs): OptionItem[] {
-    if (inputs?.runtime === RuntimeOptions.DotNet().id) {
+    if (inputs && getRuntime(inputs) === RuntimeOptions.DotNet().id) {
       return [
         CapabilityOptions.basicBot(),
         CapabilityOptions.aiBot(),
@@ -647,6 +647,9 @@ export class CapabilityOptions {
    * dynamic capability list, which depends on feature flags
    */
   static all(inputs?: Inputs): OptionItem[] {
+    if (inputs && getRuntime(inputs) === RuntimeOptions.DotNet().id) {
+      return CapabilityOptions.dotnetCaps(inputs);
+    }
     const capabilityOptions = [
       ...CapabilityOptions.bots(inputs),
       ...CapabilityOptions.tabs(),

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -142,12 +142,10 @@ export class RuntimeOptions {
 
 export function getRuntime(inputs: Inputs): string {
   let runtime = RuntimeOptions.NodeJS().id;
-  if (featureFlagManager.getBooleanValue(FeatureFlags.CLIDotNet)) {
+  if (inputs?.platform === Platform.VS) {
+    runtime = RuntimeOptions.DotNet().id;
+  } else if (featureFlagManager.getBooleanValue(FeatureFlags.CLIDotNet)) {
     runtime = inputs[QuestionNames.Runtime] || runtime;
-  } else {
-    if (inputs?.platform === Platform.VS) {
-      runtime = RuntimeOptions.DotNet().id;
-    }
   }
   return runtime;
 }

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -94,7 +94,7 @@ export function projectTypeQuestion(): SingleSelectQuestion {
         staticOptions.push(ProjectTypeOptions.copilotPlugin(inputs.platform));
       }
 
-      if (inputs.runtime === RuntimeOptions.NodeJS().id) {
+      if (getRuntime(inputs) === RuntimeOptions.NodeJS().id) {
         staticOptions.push(ProjectTypeOptions.customCopilot(inputs.platform));
       }
 
@@ -109,7 +109,7 @@ export function projectTypeQuestion(): SingleSelectQuestion {
         if (projectType) {
           return [projectType];
         }
-      } else if (inputs.runtime === RuntimeOptions.NodeJS().id) {
+      } else if (getRuntime(inputs) === RuntimeOptions.NodeJS().id) {
         if (featureFlagManager.getBooleanValue(FeatureFlags.OfficeAddin)) {
           staticOptions.push(ProjectTypeOptions.officeAddin(inputs.platform));
         } else {
@@ -214,12 +214,8 @@ export function capabilityQuestion(): SingleSelectQuestion {
       }
 
       if (inputs.nonInteractive && inputs.platform === Platform.CLI) {
-        if (inputs.runtime === RuntimeOptions.DotNet().id) {
-          return CapabilityOptions.dotnetCaps(inputs);
-        } else {
-          //cli non-interactive mode the choice list is the same as staticOptions
-          return CapabilityOptions.all(inputs);
-        }
+        //cli non-interactive mode the choice list is the same as staticOptions
+        return CapabilityOptions.all(inputs);
       }
 
       // capabilities if VSC or CLI interactive mode
@@ -545,7 +541,7 @@ export function getOfficeAddinTemplateConfig(): IOfficeAddinHostConfig {
 export function getLanguageOptions(inputs: Inputs): OptionItem[] {
   const runtime = getRuntime(inputs);
   // dotnet runtime only supports C#
-  if (runtime === RuntimeOptions.DotNet().id || inputs.platform === Platform.VS) {
+  if (getRuntime(inputs) === RuntimeOptions.DotNet().id) {
     return [{ id: ProgrammingLanguage.CSharp, label: "C#" }];
   }
   const capabilities = inputs[QuestionNames.Capabilities] as string;

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -541,7 +541,7 @@ export function getOfficeAddinTemplateConfig(): IOfficeAddinHostConfig {
 export function getLanguageOptions(inputs: Inputs): OptionItem[] {
   const runtime = getRuntime(inputs);
   // dotnet runtime only supports C#
-  if (getRuntime(inputs) === RuntimeOptions.DotNet().id) {
+  if (runtime === RuntimeOptions.DotNet().id) {
     return [{ id: ProgrammingLanguage.CSharp, label: "C#" }];
   }
   const capabilities = inputs[QuestionNames.Capabilities] as string;
@@ -1386,12 +1386,13 @@ export function capabilitySubTree(): IQTreeNode {
         data: programmingLanguageQuestion(),
         condition: (inputs: Inputs) => {
           return (
-            !!inputs[QuestionNames.Capabilities] &&
-            inputs[QuestionNames.Capabilities] !== CapabilityOptions.copilotPluginApiSpec().id &&
-            inputs[QuestionNames.Capabilities] !== CapabilityOptions.customizeGptBasic().id &&
-            inputs[QuestionNames.MeArchitectureType] !== MeArchitectureOptions.apiSpec().id &&
-            inputs[QuestionNames.Capabilities] !== CapabilityOptions.officeAddinImport().id &&
-            inputs[QuestionNames.Capabilities] !== CapabilityOptions.outlookAddinImport().id
+            (!!inputs[QuestionNames.Capabilities] &&
+              inputs[QuestionNames.Capabilities] !== CapabilityOptions.copilotPluginApiSpec().id &&
+              inputs[QuestionNames.Capabilities] !== CapabilityOptions.customizeGptBasic().id &&
+              inputs[QuestionNames.MeArchitectureType] !== MeArchitectureOptions.apiSpec().id &&
+              inputs[QuestionNames.Capabilities] !== CapabilityOptions.officeAddinImport().id &&
+              inputs[QuestionNames.Capabilities] !== CapabilityOptions.outlookAddinImport().id) ||
+            getRuntime(inputs) === RuntimeOptions.DotNet().id
           );
         },
       },

--- a/packages/vscode-extension/test/officeChat/utils.test.ts
+++ b/packages/vscode-extension/test/officeChat/utils.test.ts
@@ -174,7 +174,7 @@ describe("File: officeChat/utils.ts", () => {
           shortDescription: "Using Shape related APIs to insert and format to work as a dashboard.",
           fullDescription:
             "The sample add-in demonstrates Excel add-in capablities to help users using shape API to work as a dashboard.",
-          tags: ["TS", "Shape", "Excel", "Office Add-in"],
+          tags: ["TS", "Shape", "Excel"],
           time: "5min to run",
           thumbnailPath: "assets/thumbnail.png",
           suggested: false,


### PR DESCRIPTION
E2E: https://github.com/OfficeDev/teams-toolkit/actions/runs/9969559504
- Fix issue that user cannot create project in VS if TEAMSFX_CLI_DOTNET flag is enabled
- [Bug 28682942](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28682942): [Cli]Display all project types when creating projects in . Net core
![image](https://github.com/user-attachments/assets/d615b583-48dc-4407-82d2-a5aee3160569)
