### PR TITLE
fix: upgrade basic bot and link base on store policy

### DIFF
--- a/templates/csharp/default-bot/appPackage/manifest.json.tpl
+++ b/templates/csharp/default-bot/appPackage/manifest.json.tpl
@@ -31,7 +31,18 @@
             "groupChat"
         ],
         "supportsFiles": false,
-        "isNotificationOnly": false
+        "isNotificationOnly": false,
+        "commandLists": [
+            {
+              "scopes": ["personal", "team", "groupChat"],
+              "commands": [
+                  {
+                      "title": "Hi",
+                      "description": "Say hi to the bot."
+                  }
+              ]
+            }
+        ]
         }
     ],
     "composeExtensions": [

--- a/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
@@ -33,7 +33,7 @@
                         "compose",
                         "commandBox"
                     ],
-                    "description": "Test command to run query",
+                    "description": "Test command to run query, need to implement in the code",
                     "title": "Search",
                     "type": "query",
                     "parameters": [

--- a/templates/js/default-bot/appPackage/manifest.json.tpl
+++ b/templates/js/default-bot/appPackage/manifest.json.tpl
@@ -31,7 +31,18 @@
                 "groupChat"
             ],
             "supportsFiles": false,
-            "isNotificationOnly": false
+            "isNotificationOnly": false,
+            "commandLists": [
+                {
+                  "scopes": ["personal", "team", "groupChat"],
+                  "commands": [
+                      {
+                          "title": "Hi",
+                          "description": "Say hi to the bot."
+                      }
+                  ]
+                }
+            ]
         }
     ],
     "composeExtensions": [],

--- a/templates/js/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/js/link-unfurling/appPackage/manifest.json.tpl
@@ -33,7 +33,7 @@
                         "compose",
                         "commandBox"
                     ],
-                    "description": "Test command to run query",
+                    "description": "Test command to run query, need to implement in the code",
                     "title": "Search",
                     "type": "query",
                     "parameters": [

--- a/templates/ts/default-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/default-bot/appPackage/manifest.json.tpl
@@ -31,7 +31,18 @@
                 "groupChat"
             ],
             "supportsFiles": false,
-            "isNotificationOnly": false
+            "isNotificationOnly": false,
+            "commandLists": [
+                {
+                  "scopes": ["personal", "team", "groupChat"],
+                  "commands": [
+                      {
+                          "title": "Hi",
+                          "description": "Say hi to the bot."
+                      }
+                  ]
+                }
+            ]
         }
     ],
     "composeExtensions": [],

--- a/templates/ts/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/ts/link-unfurling/appPackage/manifest.json.tpl
@@ -33,7 +33,7 @@
                         "compose",
                         "commandBox"
                     ],
-                    "description": "Test command to run query",
+                    "description": "Test command to run query, need to implement in the code",
                     "title": "Search",
                     "type": "query",
                     "parameters": [


### PR DESCRIPTION
Upgrade basic bot template (js ts csharp version) and message extension link unfurling template (js ts csharp verison)

Based on Teams Store validation guidelines (https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/appsource/prepare/teams-store-validation-guidelines)

## Reference
### basic bot
You must list at least one valid bot command in the items.commands.title section of the app manifest and add a suitable description that gives clarity to the user on the bot command and its usage. Bot commands listed in the commandLists section of the app manifest surface as prepopulated commands in the bot command menu and provide a way forward for the new user to interact with the bot. 

### message extension link unfurling template
Search based message extensions must provide text that helps the users to search effectively.


