### PR TITLE
fix: upgrade command bot template based on Teams store policy

### DIFF
--- a/templates/csharp/command-and-response/Commands/GenericCommandHandler.cs.tpl
+++ b/templates/csharp/command-and-response/Commands/GenericCommandHandler.cs.tpl
@@ -1,0 +1,58 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.TeamsFx.Conversation;
+
+namespace {{SafeProjectName}}.Commands
+{
+    /// <summary>
+    /// The <see cref="GenericCommandHandler"/> registers patterns with the <see cref="ITeamsCommandHandler"/> and
+    /// responds with appropriate messages if the user types general command inputs, such as "hi", "hello", and "help".
+    /// </summary>
+    public class GenericCommandHandler : ITeamsCommandHandler
+    {
+        private readonly ILogger<GenericCommandHandler> _logger;
+    
+        public IEnumerable<ITriggerPattern> TriggerPatterns => new List<ITriggerPattern>
+        {
+            // Used to trigger the command handler if the command text contains 'helloWorld'
+            new RegExpTrigger("^.+$")
+        };
+    
+        public GenericCommandHandler(ILogger<GenericCommandHandler> logger)
+        {
+            _logger = logger;
+        }
+    
+        public async Task<ICommandResponse> HandleCommandAsync(ITurnContext turnContext, CommandMessage message, CancellationToken cancellationToken = default)
+        {
+            _logger?.LogInformation($"App received message: {message.Text}");
+    
+            // Determine the appropriate response based on the command  
+            string responseText;
+            switch (message.Text)
+            {
+                case "hi":
+                    responseText = "Hi there! I'm your Command Bot, here to assist you with your tasks. Type 'help' for a list of available commands.";
+                    break;
+                case "hello":
+                    responseText = "Hello! I'm your Command Bot, always ready to help you out. If you need assistance, just type 'help' to see the available commands.";
+                    break;
+                case "help":
+                    responseText = "Here's a list of commands I can help you with:\n" +
+                                   "- 'hi' or 'hello': Say hi or hello to me, and I'll greet you back.\n" +
+                                   "- 'help': Get a list of available commands.\n" +
+                                   "- 'helloworld': See a sample response from me.\n" +
+                                   "\nFeel free to ask for help anytime you need it!";
+                    break;
+                default:
+                    responseText = "Sorry, command unknown. Please type 'help' to see the list of available commands.";
+                    break;
+            }
+    
+            // Build the response activity  
+            var activity = MessageFactory.Text(responseText);
+    
+            // Send response  
+            return new ActivityCommandResponse(activity);
+        }
+    }
+}

--- a/templates/csharp/command-and-response/Program.cs.tpl
+++ b/templates/csharp/command-and-response/Program.cs.tpl
@@ -29,6 +29,7 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>());
 
 // Create command handlers and the Conversation with command-response feature enabled.
 builder.Services.AddSingleton<HelloWorldCommandHandler>();
+builder.Services.AddSingleton<GenericCommandHandler>();
 builder.Services.AddSingleton(sp =>
 {
     var options = new ConversationOptions()
@@ -36,7 +37,10 @@ builder.Services.AddSingleton(sp =>
         Adapter = sp.GetService<CloudAdapter>(),
         Command = new CommandOptions()
         {
-            Commands = new List<ITeamsCommandHandler> { sp.GetService<HelloWorldCommandHandler>() }
+            Commands = new List<ITeamsCommandHandler> { 
+                sp.GetService<HelloWorldCommandHandler>(), 
+                sp.GetService<GenericCommandHandler>() 
+            }
         }
     };
 

--- a/templates/csharp/command-and-response/TeamsBot.cs.tpl
+++ b/templates/csharp/command-and-response/TeamsBot.cs.tpl
@@ -1,15 +1,30 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Command Bot! I can help you with a few simple commands. Type \"helloworld\" or \"help\" to get started.";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/js/command-and-response/src/genericCommandHandler.js
+++ b/templates/js/command-and-response/src/genericCommandHandler.js
@@ -1,0 +1,35 @@
+class GenericCommandHandler {
+  triggerPatterns = new RegExp(/^.+$/);
+
+  async handleCommandReceived(context, message) {
+    // verify the command arguments which are received from the client if needed.
+    console.log(`App received message: ${message.text}`);
+
+    let response = "";
+    switch (message.text) {
+      case "hi":
+        response =
+          "Hi there! I'm your Command Bot, here to assist you with your tasks. Type 'help' for a list of available commands.";
+        break;
+      case "hello":
+        response =
+          "Hello! I'm your Command Bot, always ready to help you out. If you need assistance, just type 'help' to see the available commands.";
+        break;
+      case "help":
+        response =
+          "Here's a list of commands I can help you with:\n" +
+          "- 'hi' or 'hello': Say hi or hello to me, and I'll greet you back.\n" +
+          "- 'help': Get a list of available commands.\n" +
+          "- 'helloworld': See a sample response from me.\n" +
+          "\nFeel free to ask for help anytime you need it!";
+        break;
+      default:
+        response = `Sorry, command unknown. Please type 'help' to see the list of available commands.`;
+    }
+    return response;
+  }
+}
+
+module.exports = {
+  GenericCommandHandler,
+};

--- a/templates/js/command-and-response/src/internal/initialize.js
+++ b/templates/js/command-and-response/src/internal/initialize.js
@@ -1,6 +1,7 @@
 const { BotBuilderCloudAdapter } = require("@microsoft/teamsfx");
 const ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 const { HelloWorldCommandHandler } = require("../helloworldCommandHandler");
+const { GenericCommandHandler } = require("../genericCommandHandler");
 const config = require("./config");
 
 // Create the command bot and register the command handlers for your app.
@@ -12,7 +13,7 @@ const commandApp = new ConversationBot({
   adapterConfig: config,
   command: {
     enabled: true,
-    commands: [new HelloWorldCommandHandler()],
+    commands: [new HelloWorldCommandHandler(), new GenericCommandHandler()],
   },
 });
 

--- a/templates/js/command-and-response/src/teamsBot.js
+++ b/templates/js/command-and-response/src/teamsBot.js
@@ -1,10 +1,24 @@
 const { TeamsActivityHandler } = require("botbuilder");
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            'Welcome to the Command Bot! I can help you with a few simple commands. Type "helloworld" or "help" to get started.'
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }
 

--- a/templates/ts/command-and-response/src/genericCommandHandler.ts
+++ b/templates/ts/command-and-response/src/genericCommandHandler.ts
@@ -1,0 +1,41 @@
+import { Activity, TurnContext } from "botbuilder";
+import { CommandMessage, TeamsFxBotCommandHandler, TriggerPatterns } from "@microsoft/teamsfx";
+
+/**
+ * The `GenericCommandHandler` registers patterns with the `TeamsFxBotCommandHandler` and responds
+ * with appropriate messages if the user types general command inputs, such as "hi", "hello", and "help".
+ */
+export class GenericCommandHandler implements TeamsFxBotCommandHandler {
+  triggerPatterns: TriggerPatterns = new RegExp(/^.+$/);
+
+  async handleCommandReceived(
+    context: TurnContext,
+    message: CommandMessage
+  ): Promise<string | Partial<Activity> | void> {
+    console.log(`App received message: ${message.text}`);
+
+    let response = "";
+    switch (message.text) {
+      case "hi":
+        response =
+          "Hi there! I'm your Command Bot, here to assist you with your tasks. Type 'help' for a list of available commands.";
+        break;
+      case "hello":
+        response =
+          "Hello! I'm your Command Bot, always ready to help you out. If you need assistance, just type 'help' to see the available commands.";
+        break;
+      case "help":
+        response =
+          "Here's a list of commands I can help you with:\n" +
+          "- 'hi' or 'hello': Say hi or hello to me, and I'll greet you back.\n" +
+          "- 'help': Get a list of available commands.\n" +
+          "- 'helloworld': See a sample response from me.\n" +
+          "\nFeel free to ask for help anytime you need it!";
+        break;
+      default:
+        response = `Sorry, command unknown. Please type 'help' to see the list of available commands.`;
+    }
+
+    return response;
+  }
+}

--- a/templates/ts/command-and-response/src/internal/initialize.ts
+++ b/templates/ts/command-and-response/src/internal/initialize.ts
@@ -1,4 +1,5 @@
 import { HelloWorldCommandHandler } from "../helloworldCommandHandler";
+import { GenericCommandHandler } from "../genericCommandHandler";
 import { BotBuilderCloudAdapter } from "@microsoft/teamsfx";
 import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
@@ -12,6 +13,6 @@ export const commandApp = new ConversationBot({
   adapterConfig: config,
   command: {
     enabled: true,
-    commands: [new HelloWorldCommandHandler()],
+    commands: [new HelloWorldCommandHandler(), new GenericCommandHandler()],
   },
 });

--- a/templates/ts/command-and-response/src/teamsBot.ts
+++ b/templates/ts/command-and-response/src/teamsBot.ts
@@ -1,9 +1,23 @@
 import { TeamsActivityHandler } from "botbuilder";
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            'Welcome to the Command Bot! I can help you with a few simple commands. Type "helloworld" or "help" to get started.'
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }


### PR DESCRIPTION
Upgrade command bot template (js ts csharp version)

Based on Teams Store validation guidelines (https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/appsource/prepare/teams-store-validation-guidelines)

## Reference
### command bot
All commands that your bot supports must work correctly, including generic commands such as Hi, Hello, and Help. [Mandatory Fix]
Bot commands mustn't lead a user to a dead end, the commands must always provide a way forward. [Mandatory Fix]
Bots must always provide a valid response to a user input even if the input is irrelevant or improper. [Mandatory Fix]
Bots must provide a valid response to invalid user commands. Bots mustn't dead-end the user or display an error if a user sends an invalid bot command. [Mandatory Fix]
Welcome message must auto trigger on app install in a personal scope. If the bot doesn't send a welcome message in a personal scope, the user is lead to a dead-end. If the app doesn't include a complex configuration workflow, it's optional for the developer to trigger a welcome message in the channel or group chat scope. [Mandatory Fix]
Welcome message mustn't dead-end the user. Welcome message must include the value offered by the bot to the users who installed the bot in channel, how to configure the bot, and briefly describe all supported bot commands. You can display the welcome message using an Adaptive Card with buttons for better usability. [Mandatory Fix]