### PR TITLE
fix: upgrade notification bot template based on Teams store policy

### DIFF
--- a/templates/csharp/notification-http-timer-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-http-timer-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-http-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-http-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-http-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-trigger/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-http-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-http-trigger/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-timer-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-timer-trigger-isolated/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-timer-trigger/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/csharp/notification-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-timer-trigger/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -1,15 +1,31 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
     /// <summary>
-    /// An empty bot handler.
+    /// Bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
     public class TeamsBot : TeamsActivityHandler
     {
-        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText), cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/templates/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            var welcomeText = "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!";
             foreach (var member in membersAdded)
             {

--- a/templates/js/notification-http-timer-trigger/src/teamsBot.js
+++ b/templates/js/notification-http-timer-trigger/src/teamsBot.js
@@ -1,10 +1,25 @@
 const { TeamsActivityHandler } = require("botbuilder");
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }
 

--- a/templates/js/notification-http-timer-trigger/src/teamsBot.js
+++ b/templates/js/notification-http-timer-trigger/src/teamsBot.js
@@ -12,7 +12,7 @@ class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/js/notification-http-trigger/src/teamsBot.js
+++ b/templates/js/notification-http-trigger/src/teamsBot.js
@@ -1,10 +1,25 @@
 const { TeamsActivityHandler } = require("botbuilder");
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }
 

--- a/templates/js/notification-http-trigger/src/teamsBot.js
+++ b/templates/js/notification-http-trigger/src/teamsBot.js
@@ -12,7 +12,7 @@ class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/js/notification-restify/src/teamsBot.js
+++ b/templates/js/notification-restify/src/teamsBot.js
@@ -1,10 +1,25 @@
 const { TeamsActivityHandler } = require("botbuilder");
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }
 

--- a/templates/js/notification-restify/src/teamsBot.js
+++ b/templates/js/notification-restify/src/teamsBot.js
@@ -12,7 +12,7 @@ class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/js/notification-timer-trigger/src/teamsBot.js
+++ b/templates/js/notification-timer-trigger/src/teamsBot.js
@@ -12,7 +12,7 @@ class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/js/notification-timer-trigger/src/teamsBot.js
+++ b/templates/js/notification-timer-trigger/src/teamsBot.js
@@ -1,10 +1,25 @@
 const { TeamsActivityHandler } = require("botbuilder");
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }
 

--- a/templates/ts/notification-http-timer-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-http-timer-trigger/src/teamsBot.ts
@@ -12,7 +12,7 @@ export class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/ts/notification-http-timer-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-http-timer-trigger/src/teamsBot.ts
@@ -1,9 +1,24 @@
 import { TeamsActivityHandler } from "botbuilder";
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests or timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }

--- a/templates/ts/notification-http-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-http-trigger/src/teamsBot.ts
@@ -1,9 +1,24 @@
 import { TeamsActivityHandler } from "botbuilder";
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }

--- a/templates/ts/notification-http-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-http-trigger/src/teamsBot.ts
@@ -12,7 +12,7 @@ export class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/ts/notification-restify/src/teamsBot.ts
+++ b/templates/ts/notification-restify/src/teamsBot.ts
@@ -1,9 +1,24 @@
 import { TeamsActivityHandler } from "botbuilder";
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }

--- a/templates/ts/notification-restify/src/teamsBot.ts
+++ b/templates/ts/notification-restify/src/teamsBot.ts
@@ -12,7 +12,7 @@ export class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by HTTP post requests. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/ts/notification-timer-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-timer-trigger/src/teamsBot.ts
@@ -12,7 +12,7 @@ export class TeamsBot extends TeamsActivityHandler {
       for (let cnt = 0; cnt < membersAdded.length; cnt++) {
         if (membersAdded[cnt].id) {
           await context.sendActivity(
-            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules. " +
               "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
           );
           break;

--- a/templates/ts/notification-timer-trigger/src/teamsBot.ts
+++ b/templates/ts/notification-timer-trigger/src/teamsBot.ts
@@ -1,9 +1,24 @@
 import { TeamsActivityHandler } from "botbuilder";
 
-// An empty teams activity handler.
+// Teams activity handler.
 // You can add your customization code here to extend your bot logic if needed.
 export class TeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
+
+    // Listen to MembersAdded event, view https://docs.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications for more events
+    this.onMembersAdded(async (context, next) => {
+      const membersAdded = context.activity.membersAdded;
+      for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+        if (membersAdded[cnt].id) {
+          await context.sendActivity(
+            "Welcome to the Notification Bot! I am designed to send you updates and alerts using Adaptive Cards triggered by timer schedules." +
+              "Please note that I am a notification-only bot and you can't interact with me. Follow the README in the project and stay tuned for notifications!"
+          );
+          break;
+        }
+      }
+      await next();
+    });
   }
 }


### PR DESCRIPTION
Upgrade notification bot template (js ts csharp version)

Based on Teams Store validation guidelines (https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/appsource/prepare/teams-store-validation-guidelines)

## Reference
### Notification only bots
Notification only bots must send a welcome message that clarifies that the bot is a notification only bot and users won't be able to interact with the bot. [Mandatory Fix]