### PR TITLE
refactor: rename feature flag name

### DIFF
--- a/packages/cli/src/commands/models/add.ts
+++ b/packages/cli/src/commands/models/add.ts
@@ -4,13 +4,10 @@ import { CLICommand } from "@microsoft/teamsfx-api";
 import { commands } from "../../resource";
 import { addSPFxWebpartCommand } from "./addSPFxWebpart";
 import { addPluginCommand } from "./addPlugin";
-import { FeatureFlags, featureFlagManager } from "@microsoft/teamsfx-core";
+import { isCopilotExtensionEnabled } from "@microsoft/teamsfx-core";
 
 const adjustCommands = (): CLICommand[] => {
-  if (
-    featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) ||
-    featureFlagManager.getBooleanValue(FeatureFlags.CopilotPlugin)
-  ) {
+  if (isCopilotExtensionEnabled()) {
     return [addSPFxWebpartCommand, addPluginCommand];
   } else {
     return [addSPFxWebpartCommand];

--- a/packages/cli/src/commands/models/add.ts
+++ b/packages/cli/src/commands/models/add.ts
@@ -7,7 +7,10 @@ import { addPluginCommand } from "./addPlugin";
 import { FeatureFlags, featureFlagManager } from "@microsoft/teamsfx-core";
 
 const adjustCommands = (): CLICommand[] => {
-  if (featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)) {
+  if (
+    featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) ||
+    featureFlagManager.getBooleanValue(FeatureFlags.CopilotPlugin)
+  ) {
     return [addSPFxWebpartCommand, addPluginCommand];
   } else {
     return [addSPFxWebpartCommand];

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -16,6 +16,7 @@ import {
   CreateProjectOptions,
   featureFlagManager,
   FeatureFlags,
+  isCopilotExtensionEnabled,
   MeArchitectureOptions,
   QuestionNames,
 } from "@microsoft/teamsfx-core";
@@ -46,10 +47,7 @@ function adjustOptions(options: CLICommandOption[]) {
     }
   }
 
-  if (
-    !featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) &&
-    !featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)
-  ) {
+  if (!isCopilotExtensionEnabled()) {
     //skip Copilot extension questions if the feature flag is not enabled.
     const questionsToDelete = [QuestionNames.ApiPluginType, QuestionNames.WithPlugin];
     options = options.filter((option) => !questionsToDelete.includes(option.name as QuestionNames));

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -46,7 +46,10 @@ function adjustOptions(options: CLICommandOption[]) {
     }
   }
 
-  if (!featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)) {
+  if (
+    !featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) &&
+    !featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)
+  ) {
     //skip Copilot extension questions if the feature flag is not enabled.
     const questionsToDelete = [QuestionNames.ApiPluginType, QuestionNames.WithPlugin];
     options = options.filter((option) => !questionsToDelete.includes(option.name as QuestionNames));

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -15,6 +15,7 @@ export class FeatureFlagName {
   static readonly OfficeAddin = "TEAMSFX_OFFICE_ADDIN";
   static readonly CopilotExtension = "DEVELOP_COPILOT_EXTENSION";
   static readonly CopilotPlugin = "DEVELOP_COPILOT_PLUGIN";
+  static readonly DeclarativeCopilot = "TEAMSFX_DECLARATIVE_COPILOT";
   static readonly SampleConfigBranch = "TEAMSFX_SAMPLE_CONFIG_BRANCH";
   static readonly TestTool = "TEAMSFX_TEST_TOOL";
   static readonly METestTool = "TEAMSFX_ME_TEST_TOOL";
@@ -43,7 +44,11 @@ export class FeatureFlags {
   static readonly CopilotPlugin = {
     name: FeatureFlagName.CopilotPlugin,
     defaultValue: "false",
-  }; // old feature flag for Copilot plugin. Keep it for backwards compatibility. CLI users now can enable either DEVELOP_COPILOT_EXTENSION or DEVELOP_COPILOT_PLUGIN for Copilot related features.
+  }; // old feature flag. Keep it for backwards compatibility.
+  static readonly DeclarativeCopilot = {
+    name: FeatureFlagName.DeclarativeCopilot,
+    defaultValue: "false",
+  }; // old feature flag. Keep it for backwards compatibility.
   static readonly TestTool = { name: FeatureFlagName.TestTool, defaultValue: "true" };
   static readonly METestTool = { name: FeatureFlagName.METestTool, defaultValue: "true" };
   static readonly OfficeAddin = { name: FeatureFlagName.OfficeAddin, defaultValue: "false" };
@@ -78,7 +83,8 @@ export class FeatureFlags {
 export function isCopilotExtensionEnabled(): boolean {
   return (
     featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) ||
-    featureFlagManager.getBooleanValue(FeatureFlags.CopilotPlugin)
+    featureFlagManager.getBooleanValue(FeatureFlags.CopilotPlugin) ||
+    featureFlagManager.getBooleanValue(FeatureFlags.DeclarativeCopilot)
   );
 }
 

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -13,7 +13,7 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 export class FeatureFlagName {
   static readonly CLIDotNet = "TEAMSFX_CLI_DOTNET";
   static readonly OfficeAddin = "TEAMSFX_OFFICE_ADDIN";
-  static readonly CopilotExtension = "DEVELOP_COPILOT_PLUGIN"; // TODO: rename feature flag
+  static readonly CopilotExtension = "DEVELOP_COPILOT_EXTENSION";
   static readonly SampleConfigBranch = "TEAMSFX_SAMPLE_CONFIG_BRANCH";
   static readonly TestTool = "TEAMSFX_TEST_TOOL";
   static readonly METestTool = "TEAMSFX_ME_TEST_TOOL";

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -14,6 +14,7 @@ export class FeatureFlagName {
   static readonly CLIDotNet = "TEAMSFX_CLI_DOTNET";
   static readonly OfficeAddin = "TEAMSFX_OFFICE_ADDIN";
   static readonly CopilotExtension = "DEVELOP_COPILOT_EXTENSION";
+  static readonly CopilotPlugin = "DEVELOP_COPILOT_PLUGIN";
   static readonly SampleConfigBranch = "TEAMSFX_SAMPLE_CONFIG_BRANCH";
   static readonly TestTool = "TEAMSFX_TEST_TOOL";
   static readonly METestTool = "TEAMSFX_ME_TEST_TOOL";
@@ -39,6 +40,10 @@ export class FeatureFlags {
     name: FeatureFlagName.CopilotExtension,
     defaultValue: "false",
   };
+  static readonly CopilotPlugin = {
+    name: FeatureFlagName.CopilotPlugin,
+    defaultValue: "false",
+  }; // old feature flag for Copilot plugin. Keep it for backwards compatibility. CLI users now can enable either DEVELOP_COPILOT_EXTENSION or DEVELOP_COPILOT_PLUGIN for Copilot related features.
   static readonly TestTool = { name: FeatureFlagName.TestTool, defaultValue: "true" };
   static readonly METestTool = { name: FeatureFlagName.METestTool, defaultValue: "true" };
   static readonly OfficeAddin = { name: FeatureFlagName.OfficeAddin, defaultValue: "false" };
@@ -68,6 +73,13 @@ export class FeatureFlags {
     name: FeatureFlagName.DevTunnelTest,
     defaultValue: "false",
   };
+}
+
+export function isCopilotExtensionEnabled(): boolean {
+  return (
+    featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension) ||
+    featureFlagManager.getBooleanValue(FeatureFlags.CopilotPlugin)
+  );
 }
 
 export class FeatureFlagManager {

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -30,6 +30,7 @@ export {
   featureFlagManager,
   isFeatureFlagEnabled,
   FeatureFlagName,
+  isCopilotExtensionEnabled,
 } from "./common/featureFlags";
 export { globalStateGet, globalStateUpdate } from "./common/globalState";
 export { getDefaultString, getLocalizedString } from "./common/localizeUtils";

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { Inputs, OptionItem, Platform } from "@microsoft/teamsfx-api";
-import { FeatureFlags, featureFlagManager } from "../common/featureFlags";
+import {
+  FeatureFlags,
+  featureFlagManager,
+  isCopilotExtensionEnabled,
+} from "../common/featureFlags";
 import { getLocalizedString } from "../common/localizeUtils";
 import { OfficeAddinProjectConfig } from "../component/generator/officeXMLAddin/projectConfig";
 
@@ -204,7 +208,7 @@ export class ProjectTypeOptions {
       label: `${platform === Platform.VSCode ? "$(symbol-keyword) " : ""}${getLocalizedString(
         "core.MessageExtensionOption.label"
       )}`,
-      detail: featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)
+      detail: isCopilotExtensionEnabled()
         ? getLocalizedString(
             "core.createProjectQuestion.projectType.messageExtension.copilotEnabled.detail"
           )
@@ -434,7 +438,7 @@ export class CapabilityOptions {
     return {
       id: "search-app",
       label: `${getLocalizedString("core.M365SearchAppOptionItem.label")}`,
-      detail: featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)
+      detail: isCopilotExtensionEnabled()
         ? getLocalizedString("core.M365SearchAppOptionItem.copilot.detail")
         : getLocalizedString("core.M365SearchAppOptionItem.detail"),
     };
@@ -643,7 +647,7 @@ export class CapabilityOptions {
       ...CapabilityOptions.tabs(),
       ...CapabilityOptions.collectMECaps(),
     ];
-    if (featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)) {
+    if (isCopilotExtensionEnabled()) {
       capabilityOptions.push(...CapabilityOptions.copilotExtensions());
     }
     capabilityOptions.push(...CapabilityOptions.customCopilots());
@@ -866,7 +870,7 @@ export class MeArchitectureOptions {
     return [
       MeArchitectureOptions.newApi(),
       MeArchitectureOptions.apiSpec(),
-      featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)
+      isCopilotExtensionEnabled()
         ? MeArchitectureOptions.botPlugin()
         : MeArchitectureOptions.botMe(),
     ];

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -23,7 +23,11 @@ import * as os from "os";
 import * as path from "path";
 import { ConstantString } from "../common/constants";
 import { Correlator } from "../common/correlator";
-import { FeatureFlags, featureFlagManager } from "../common/featureFlags";
+import {
+  FeatureFlags,
+  featureFlagManager,
+  isCopilotExtensionEnabled,
+} from "../common/featureFlags";
 import { createContext } from "../common/globalVars";
 import { getLocalizedString } from "../common/localizeUtils";
 import { sampleProvider } from "../common/samples";
@@ -84,7 +88,7 @@ export function projectTypeQuestion(): SingleSelectQuestion {
     dynamicOptions: (inputs: Inputs) => {
       const staticOptions: OptionItem[] = [];
 
-      if (featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)) {
+      if (isCopilotExtensionEnabled()) {
         staticOptions.push(ProjectTypeOptions.copilotExtension(inputs.platform));
       }
 
@@ -1567,7 +1571,7 @@ export function createProjectCliHelpNode(): IQTreeNode {
   if (!featureFlagManager.getBooleanValue(FeatureFlags.CLIDotNet)) {
     deleteNames.push(QuestionNames.Runtime);
   }
-  if (!featureFlagManager.getBooleanValue(FeatureFlags.CopilotExtension)) {
+  if (!isCopilotExtensionEnabled()) {
     deleteNames.push(QuestionNames.ApiPluginType);
     deleteNames.push(QuestionNames.WithPlugin);
   }

--- a/packages/tests/src/e2e/scaffold/CopilotPluginFromExistingApi.tests.ts
+++ b/packages/tests/src/e2e/scaffold/CopilotPluginFromExistingApi.tests.ts
@@ -42,7 +42,7 @@ describe("Create Copilot plugin", () => {
     async function () {
       const env = Object.assign({}, process.env);
 
-      env["DEVELOP_COPILOT_PLUGIN"] = "true";
+      env["DEVELOP_COPILOT_EXTENSION"] = "true";
 
       const apiSpecPath = path.join(__dirname, "../", "testApiSpec.yml");
 

--- a/packages/tests/src/e2e/scaffold/CopilotPluginFromScratch.tests.ts
+++ b/packages/tests/src/e2e/scaffold/CopilotPluginFromScratch.tests.ts
@@ -42,7 +42,7 @@ describe("Create Copilot plugin", () => {
     async function () {
       const env = Object.assign({}, process.env);
 
-      env["DEVELOP_COPILOT_PLUGIN"] = "true";
+      env["DEVELOP_COPILOT_EXTENSION"] = "true";
 
       // create
       await CliHelper.createProjectWithCapability(

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1527,7 +1527,7 @@
     "configuration": {
       "title": "Teams Toolkit",
       "properties": {
-        "fx-extension.developCopilotExtension": {
+        "fx-extension.developCopilotPlugin": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable to develop Copilot extension (Reload Visual Studio Code after changing this setting to take effect). Get more info from [How to Extend Microsoft 365 Copilot](https://aka.ms/teamsfx-copilot-plugin)."

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1527,10 +1527,10 @@
     "configuration": {
       "title": "Teams Toolkit",
       "properties": {
-        "fx-extension.developCopilotPlugin": {
+        "fx-extension.developCopilotExtension": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable to develop Copilot plugin (Reload Visual Studio Code after changing this setting to take effect). Get more info from [How to Extend Microsoft 365 Copilot](https://aka.ms/teamsfx-copilot-plugin)."
+          "markdownDescription": "Enable to develop Copilot extension (Reload Visual Studio Code after changing this setting to take effect). Get more info from [How to Extend Microsoft 365 Copilot](https://aka.ms/teamsfx-copilot-plugin)."
         },
         "fx-extension.logLevel": {
           "type": "string",

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -19,8 +19,8 @@ export class ConfigManager {
       ConfigurationKey.BicepEnvCheckerEnable,
       false
     ).toString();
-    process.env["DEVELOP_COPILOT_PLUGIN"] = this.getConfiguration(
-      ConfigurationKey.CopilotPluginEnable,
+    process.env["DEVELOP_COPILOT_EXTENSION"] = this.getConfiguration(
+      ConfigurationKey.CopilotExtensionEnable,
       false
     ).toString();
   }

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,7 +3,7 @@
 export const CONFIGURATION_PREFIX = "fx-extension";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
-  CopilotExtensionEnable = "developCopilotExtension",
+  CopilotExtensionEnable = "developCopilotPlugin",
   LogLevel = "logLevel",
 }
 

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,7 +3,7 @@
 export const CONFIGURATION_PREFIX = "fx-extension";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
-  CopilotPluginEnable = "developCopilotPlugin",
+  CopilotExtensionEnable = "developCopilotExtension",
   LogLevel = "logLevel",
 }
 

--- a/schemas/pluginSchema.json
+++ b/schemas/pluginSchema.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://copilotstudio.microsoft.com/schemas/plugin-manifest-v2.1.json",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
         "schema_version": {
@@ -206,7 +206,7 @@
                         "url": {
                             "type": "string"
                         },
-                        "information_protection_url": {
+                        "information_protection_label": {
                             "type": "string"
                         },
                         "template_selector": {
@@ -218,7 +218,8 @@
                             "title",
                             "subtitle",
                             "url",
-                            "information_protection_url",
+                            "information_protection_label",
+                            "thumbnail_url",
                             "template_selector"
                         ]
                     }
@@ -384,7 +385,7 @@
         "localization-object": {
             "type": "object",
             "patternProperties": {
-                "/^[a-z]{2,3}(-[a-z]{2})?$/ui": {
+                "^(?i)[a-z]{2,3}(-[a-z]{2})?(?-i)$": {
                     "type": "object",
                     "patternProperties": {
                         "^[A-Za-z_][A-Za-z0-9_]*$": {

--- a/schemas/pluginSchema.json
+++ b/schemas/pluginSchema.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://copilotstudio.microsoft.com/schemas/plugin-manifest-v2.1.json",
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "schema_version": {
@@ -206,7 +206,7 @@
                         "url": {
                             "type": "string"
                         },
-                        "information_protection_label": {
+                        "information_protection_url": {
                             "type": "string"
                         },
                         "template_selector": {
@@ -218,8 +218,7 @@
                             "title",
                             "subtitle",
                             "url",
-                            "information_protection_label",
-                            "thumbnail_url",
+                            "information_protection_url",
                             "template_selector"
                         ]
                     }
@@ -385,7 +384,7 @@
         "localization-object": {
             "type": "object",
             "patternProperties": {
-                "^(?i)[a-z]{2,3}(-[a-z]{2})?(?-i)$": {
+                "/^[a-z]{2,3}(-[a-z]{2})?$/ui": {
                     "type": "object",
                     "patternProperties": {
                         "^[A-Za-z_][A-Za-z0-9_]*$": {


### PR DESCRIPTION
E2E: https://github.com/OfficeDev/teams-toolkit/actions/runs/10211006649
- Rename the feature flag name to "DEVELOP_COPILOT_EXTENSION". For backward combability, keep the old envs.
- Did not change the config key, since otherwise user who has already enabled the setting in VSC need to re-enable the feature again.
![image](https://github.com/user-attachments/assets/ed048e34-c6b8-4195-b614-5719b8cd9dce)
 - Feature flags will be removed once the feature is in public preview

