### PR TITLE
fix(vsc): show build intelligent getting started page for copilot apps

### DIFF
--- a/packages/vscode-extension/src/handlers/controlHandlers.ts
+++ b/packages/vscode-extension/src/handlers/controlHandlers.ts
@@ -35,27 +35,29 @@ export async function openLifecycleTreeview(args?: any[]) {
 export async function openWelcomeHandler(...args: unknown[]): Promise<Result<unknown, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.GetStarted, getTriggerFromProperty(args));
   // Open different walkthrough depending on the project type
-  const manifestRes = await manifestUtils.readAppManifest(workspaceUri?.fsPath || "");
   let isCopilotApp = false;
-  if (manifestRes.isOk()) {
-    const capabilities = manifestUtils.getCapabilities(manifestRes.value);
-    // API plugin can be detected in manifest
-    isCopilotApp = capabilities.includes("extension") || capabilities.includes("plugin");
-  }
-  if (!isCopilotApp && workspaceUri?.fsPath) {
-    // Use dependency to determine if it is a copilot app for now.
-    // TODO: use getCapabilities after manifest supports custom engine copilot.
-    const packageJsonPath = path.join(workspaceUri.fsPath, "package.json");
-    const requirementsPath = path.join(workspaceUri.fsPath, "src", "requirements.txt");
-    if (await fs.pathExists(packageJsonPath)) {
-      const packageJson = await fs.readFile(packageJsonPath);
-      if (packageJson.toString().includes('"@microsoft/teams-ai"')) {
-        isCopilotApp = true;
-      }
-    } else if (await fs.pathExists(requirementsPath)) {
-      const requirements = await fs.readFile(requirementsPath);
-      if (requirements.toString().includes("teams-ai")) {
-        isCopilotApp = true;
+  if (workspaceUri?.fsPath) {
+    const manifestRes = await manifestUtils.readAppManifest(workspaceUri?.fsPath);
+    if (manifestRes.isOk()) {
+      const capabilities = manifestUtils.getCapabilities(manifestRes.value);
+      // API plugin can be detected in manifest
+      isCopilotApp = capabilities.includes("extension") || capabilities.includes("plugin");
+    }
+    if (!isCopilotApp) {
+      // Use dependency to determine if it is a copilot app for now.
+      // TODO: use getCapabilities after manifest supports custom engine copilot.
+      const packageJsonPath = path.join(workspaceUri.fsPath, "package.json");
+      const requirementsPath = path.join(workspaceUri.fsPath, "src", "requirements.txt");
+      if (await fs.pathExists(packageJsonPath)) {
+        const packageJson = await fs.readFile(packageJsonPath);
+        if (packageJson.toString().includes('"@microsoft/teams-ai"')) {
+          isCopilotApp = true;
+        }
+      } else if (await fs.pathExists(requirementsPath)) {
+        const requirements = await fs.readFile(requirementsPath);
+        if (requirements.toString().includes("teams-ai")) {
+          isCopilotApp = true;
+        }
       }
     }
   }

--- a/packages/vscode-extension/test/handlers/controlHandlers.test.ts
+++ b/packages/vscode-extension/test/handlers/controlHandlers.test.ts
@@ -80,7 +80,7 @@ describe("Control Handlers", () => {
       );
     });
 
-    it("opens intelligent app walkthrough for python custom engine copilot apps", async () => {
+    it("opens intelligent app walkthrough for JS/TS custom engine copilot apps", async () => {
       sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
       sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
       sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
@@ -101,7 +101,7 @@ describe("Control Handlers", () => {
       );
     });
 
-    it("opens intelligent app walkthrough for js/ts custom engine copilot apps", async () => {
+    it("opens intelligent app walkthrough for python custom engine copilot apps", async () => {
       sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
       sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
       sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
@@ -119,6 +119,48 @@ describe("Control Handlers", () => {
         executeCommands,
         "workbench.action.openWalkthrough",
         "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps"
+      );
+    });
+
+    it("opens normal walkthrough for JS/TS apps without ai library", async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
+      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "/test" });
+      sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+        return path.includes("package.json");
+      });
+      sandbox.stub(fs, "readFile").resolves(Buffer.from(""));
+      const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
+      const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      await openWelcomeHandler();
+
+      sandbox.assert.calledOnceWithExactly(
+        executeCommands,
+        "workbench.action.openWalkthrough",
+        "TeamsDevApp.ms-teams-vscode-extension#teamsToolkitGetStarted"
+      );
+    });
+
+    it("opens normal walkthrough for python custom engine copilot apps", async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
+      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "/test" });
+      sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+        return path.includes("requirements.txt");
+      });
+      sandbox.stub(fs, "readFile").resolves(Buffer.from(""));
+      const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
+      const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      await openWelcomeHandler();
+
+      sandbox.assert.calledOnceWithExactly(
+        executeCommands,
+        "workbench.action.openWalkthrough",
+        "TeamsDevApp.ms-teams-vscode-extension#teamsToolkitGetStarted"
       );
     });
   });

--- a/packages/vscode-extension/test/handlers/controlHandlers.test.ts
+++ b/packages/vscode-extension/test/handlers/controlHandlers.test.ts
@@ -67,6 +67,7 @@ describe("Control Handlers", () => {
       sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
       sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
       sandbox.stub(manifestUtils, "getCapabilities").returns(["plugin"]);
+      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "/test" });
       const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
       const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
 

--- a/packages/vscode-extension/test/handlers/controlHandlers.test.ts
+++ b/packages/vscode-extension/test/handlers/controlHandlers.test.ts
@@ -1,11 +1,13 @@
-import * as vscode from "vscode";
-import * as sinon from "sinon";
-import * as chai from "chai";
-import * as globalVariables from "../../src/globalVariables";
-import * as commonUtils from "../../src/utils/commonUtils";
+import { ok, TeamsAppManifest } from "@microsoft/teamsfx-api";
+import { featureFlagManager, manifestUtils } from "@microsoft/teamsfx-core";
 import * as projectSettingsHelper from "@microsoft/teamsfx-core/build/common/projectSettingsHelper";
-import { featureFlagManager } from "@microsoft/teamsfx-core";
+import * as chai from "chai";
+import fs from "fs-extra";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { PanelType } from "../../src/controls/PanelType";
 import { WebviewPanel } from "../../src/controls/webviewPanel";
+import * as globalVariables from "../../src/globalVariables";
 import {
   openFolderHandler,
   openLifecycleTreeview,
@@ -14,12 +16,12 @@ import {
   saveTextDocumentHandler,
 } from "../../src/handlers/controlHandlers";
 import { ExtTelemetry } from "../../src/telemetry/extTelemetry";
-import { PanelType } from "../../src/controls/PanelType";
 import {
   TelemetryEvent,
   TelemetryProperty,
   TelemetryUpdateAppReason,
 } from "../../src/telemetry/extTelemetryEvents";
+import * as commonUtils from "../../src/utils/commonUtils";
 
 describe("Control Handlers", () => {
   describe("openWelcomeHandler", () => {
@@ -29,8 +31,10 @@ describe("Control Handlers", () => {
       sandbox.restore();
     });
 
-    it("openWelcomeHandler", async () => {
+    it("opens normal walkthrough", async () => {
       sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
       const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
       const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
 
@@ -43,8 +47,10 @@ describe("Control Handlers", () => {
       );
     });
 
-    it("openWelcomeHandler with chat", async () => {
+    it("opens walkthrough with chat", async () => {
       sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
       const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
       const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
 
@@ -54,6 +60,64 @@ describe("Control Handlers", () => {
         executeCommands,
         "workbench.action.openWalkthrough",
         "TeamsDevApp.ms-teams-vscode-extension#teamsToolkitGetStartedWithChat"
+      );
+    });
+
+    it("opens intelligent app walkthrough for API plugin apps", async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["plugin"]);
+      const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
+      const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      await openWelcomeHandler();
+
+      sandbox.assert.calledOnceWithExactly(
+        executeCommands,
+        "workbench.action.openWalkthrough",
+        "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps"
+      );
+    });
+
+    it("opens intelligent app walkthrough for python custom engine copilot apps", async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
+      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "/test" });
+      sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+        return path.includes("package.json");
+      });
+      sandbox.stub(fs, "readFile").resolves(Buffer.from('"@microsoft/teams-ai"'));
+      const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
+      const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      await openWelcomeHandler();
+
+      sandbox.assert.calledOnceWithExactly(
+        executeCommands,
+        "workbench.action.openWalkthrough",
+        "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps"
+      );
+    });
+
+    it("opens intelligent app walkthrough for js/ts custom engine copilot apps", async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as TeamsAppManifest));
+      sandbox.stub(manifestUtils, "getCapabilities").returns(["bot"]);
+      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "/test" });
+      sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+        return path.includes("requirements.txt");
+      });
+      sandbox.stub(fs, "readFile").resolves(Buffer.from("teams-ai"));
+      const executeCommands = sandbox.stub(vscode.commands, "executeCommand");
+      const sendTelemetryEvent = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      await openWelcomeHandler();
+
+      sandbox.assert.calledOnceWithExactly(
+        executeCommands,
+        "workbench.action.openWalkthrough",
+        "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps"
       );
     });
   });


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28855389