### PR TITLE
fix(vsc): svg not shown in react app

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/offlinePage.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/offlinePage.tsx
@@ -5,7 +5,7 @@ import "./offlinePage.scss";
 
 import * as React from "react";
 
-import OfflineImage from "../../../img/webview/sample/offline.svg";
+import OfflineImage from "../../../img/webview/sample/offline.svg?react";
 
 export default class OfflinePage extends React.Component<unknown, unknown> {
   constructor(props: unknown) {

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 
 import { Image } from "@fluentui/react";
 
-import Turtle from "../../../img/webview/sample/turtle.svg";
+import Turtle from "../../../img/webview/sample/turtle.svg?react";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";
 import { SampleProps } from "./ISamples";
 


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29034975

Effect:
![image](https://github.com/user-attachments/assets/49c20588-2a1a-4be2-be00-32615843c429)
