### PR TITLE
fix(vsc): avoid opening walkthrough again

### DIFF
--- a/packages/vscode-extension/src/handlers/autoOpenProjectHandler.ts
+++ b/packages/vscode-extension/src/handlers/autoOpenProjectHandler.ts
@@ -23,7 +23,6 @@ export async function autoOpenProjectHandler(): Promise<void> {
   const autoInstallDependency = (await globalStateGet(GlobalKey.AutoInstallDependency)) as boolean;
   if (isOpenWalkThrough) {
     await showLocalDebugMessage();
-    await openWelcomeHandler([TelemetryTriggerFrom.Auto]);
     await globalStateUpdate(GlobalKey.OpenWalkThrough, false);
 
     if (workspaceUri?.fsPath) {

--- a/packages/vscode-extension/test/handlers/autoOpenProjectHandler.test.ts
+++ b/packages/vscode-extension/test/handlers/autoOpenProjectHandler.test.ts
@@ -36,8 +36,8 @@ describe("autoOpenProjectHandler", () => {
 
     await autoOpenProjectHandler();
 
-    chai.assert.isTrue(sendTelemetryStub.calledOnce);
-    chai.assert.isTrue(executeCommandFunc.calledOnce);
+    chai.assert.isTrue(sendTelemetryStub.notCalled);
+    chai.assert.isTrue(executeCommandFunc.notCalled);
   });
 
   it("opens walk through if workspace Uri exists", async () => {
@@ -56,8 +56,8 @@ describe("autoOpenProjectHandler", () => {
 
     await autoOpenProjectHandler();
 
-    chai.assert.isTrue(sendTelemetryStub.calledOnce);
-    chai.assert.isTrue(executeCommandFunc.calledOnce);
+    chai.assert.isTrue(sendTelemetryStub.notCalled);
+    chai.assert.isTrue(executeCommandFunc.notCalled);
     chai.assert.isTrue(globalStateUpdateStub.calledTwice);
   });
 


### PR DESCRIPTION
The walkthrough will remain open so it's not necessary to open it again.
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29050508