### PR TITLE
fix: the launch profile for API Plugin templates

### DIFF
--- a/templates/common/api-plugin-existing-api/.vscode/launch.json.tpl
+++ b/templates/common/api-plugin-existing-api/.vscode/launch.json.tpl
@@ -3,23 +3,45 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in the Microsoft 365 app (Edge)",
             "type": "msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com?${account-hint}",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 1
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://teams.microsoft.com?${account-hint}",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 1
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
+                "group": "group 2: Teams",
                 "order": 2
             },
             "internalConsoleOptions": "neverOpen"

--- a/templates/csharp/api-plugin-from-scratch-bearer/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-bearer/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,7 +1,12 @@
 {
   "profiles": {
+    // Launch project within the Microsoft 365 app
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "launchUrl": "https://www.office.com/chat?auth=2",
+    },
     // Launch project within Teams
-    "Copilot (browser)": {
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }

--- a/templates/csharp/api-plugin-from-scratch-bearer/Properties/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-bearer/Properties/launchSettings.json.tpl
@@ -1,7 +1,17 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-    "Copilot (browser)": {
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "https://www.office.com/chat?auth=2",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "hotReloadProfile": "aspnetcore"
+    },
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,

--- a/templates/csharp/api-plugin-from-scratch-bearer/teamsapp.local.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-bearer/teamsapp.local.yml.tpl
@@ -107,7 +107,15 @@ provision:
       target: ./Properties/launchSettings.json
       content:
         profiles:
-          Copilot (browser):
+          Microsoft 365 app (browser):
+            commandName: "Project"
+            dotnetRunMessages: true
+            launchBrowser: true
+            launchUrl: "https://www.office.com/chat?auth=2"
+            environmentVariables:
+              ASPNETCORE_ENVIRONMENT: "Development"
+            hotReloadProfile: "aspnetcore"
+          Microsoft Teams (browser):
             commandName: "Project"
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true

--- a/templates/csharp/api-plugin-from-scratch-oauth/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,7 +1,12 @@
 {
   "profiles": {
+    // Launch project within the Microsoft 365 app
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "launchUrl": "https://www.office.com/chat?auth=2",
+    },
     // Launch project within Teams
-    "Copilot (browser)": {
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }

--- a/templates/csharp/api-plugin-from-scratch-oauth/Properties/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/Properties/launchSettings.json.tpl
@@ -1,7 +1,17 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-    "Copilot (browser)": {
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "https://www.office.com/chat?auth=2",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "hotReloadProfile": "aspnetcore"
+    },
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,

--- a/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.local.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.local.yml.tpl
@@ -60,7 +60,15 @@ provision:
       target: ./Properties/launchSettings.json
       content:
         profiles:
-          Copilot (browser):
+          Microsoft 365 app (browser):
+            commandName: "Project"
+            dotnetRunMessages: true
+            launchBrowser: true
+            launchUrl: "https://www.office.com/chat?auth=2"
+            environmentVariables:
+              ASPNETCORE_ENVIRONMENT: "Development"
+            hotReloadProfile: "aspnetcore"
+          Microsoft Teams (browser):
             commandName: "Project"
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true

--- a/templates/csharp/api-plugin-from-scratch/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,7 +1,12 @@
 {
   "profiles": {
-    // Launch project within Copilot
-    "Copilot (browser)": {
+    // Launch project within the Microsoft 365 app
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "launchUrl": "https://www.office.com/chat?auth=2",
+    },
+    // Launch project within Teams
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }

--- a/templates/csharp/api-plugin-from-scratch/Properties/launchSettings.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch/Properties/launchSettings.json.tpl
@@ -1,7 +1,17 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-    "Copilot (browser)": {
+    "Microsoft 365 app (browser)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "https://www.office.com/chat?auth=2",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "hotReloadProfile": "aspnetcore"
+    },
+    "Microsoft Teams (browser)": {
       "commandName": "Project",
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,

--- a/templates/csharp/api-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -60,7 +60,15 @@ provision:
       target: ./Properties/launchSettings.json
       content:
         profiles:
-          Copilot (browser):
+          Microsoft 365 app (browser):
+            commandName: "Project"
+            dotnetRunMessages: true
+            launchBrowser: true
+            launchUrl: "https://www.office.com/chat?auth=2"
+            environmentVariables:
+              ASPNETCORE_ENVIRONMENT: "Development"
+            hotReloadProfile: "aspnetcore"
+          Microsoft Teams (browser):
             commandName: "Project"
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true

--- a/templates/js/api-plugin-from-scratch-bearer/.vscode/launch.json.tpl
+++ b/templates/js/api-plugin-from-scratch-bearer/.vscode/launch.json.tpl
@@ -3,7 +3,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch App in Copilot (Edge)",
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -14,10 +44,11 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Launch App in Copilot (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -28,27 +59,39 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -65,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
             "configurations": [
-                "Launch App in Copilot (Edge)",
+                "Launch App in the Microsoft 365 app (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in the Microsoft 365 app (Chrome)",
             "configurations": [
-                "Launch App in Copilot (Chrome)",
+                "Launch App in the Microsoft 365 app (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
+            "configurations": [
+                "Launch App in Teams (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Chrome)",
+            "configurations": [
+                "Launch App in Teams (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -110,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true

--- a/templates/js/api-plugin-from-scratch-oauth/.vscode/launch.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/.vscode/launch.json.tpl
@@ -3,7 +3,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch App in Copilot (Edge)",
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -14,10 +44,11 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Launch App in Copilot (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -28,27 +59,39 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -65,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
             "configurations": [
-                "Launch App in Copilot (Edge)",
+                "Launch App in the Microsoft 365 app (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in the Microsoft 365 app (Chrome)",
             "configurations": [
-                "Launch App in Copilot (Chrome)",
+                "Launch App in the Microsoft 365 app (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
+            "configurations": [
+                "Launch App in Teams (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Chrome)",
+            "configurations": [
+                "Launch App in Teams (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -110,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true

--- a/templates/js/api-plugin-from-scratch/.vscode/launch.json.tpl
+++ b/templates/js/api-plugin-from-scratch/.vscode/launch.json.tpl
@@ -3,6 +3,36 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
             "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
@@ -33,24 +63,35 @@
             "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -67,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
+            "configurations": [
+                "Launch App in the Microsoft 365 app (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in the Microsoft 365 app (Chrome)",
+            "configurations": [
+                "Launch App in the Microsoft 365 app (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
             "configurations": [
                 "Launch App in Teams (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in Teams (Chrome)",
             "configurations": [
                 "Launch App in Teams (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -112,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true

--- a/templates/ts/api-plugin-from-scratch-bearer/.vscode/launch.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-bearer/.vscode/launch.json.tpl
@@ -3,7 +3,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch App in Copilot (Edge)",
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -14,10 +44,11 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Launch App in Copilot (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -28,27 +59,39 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -65,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
             "configurations": [
-                "Launch App in Copilot (Edge)",
+                "Launch App in the Microsoft 365 app (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in the Microsoft 365 app (Chrome)",
             "configurations": [
-                "Launch App in Copilot (Chrome)",
+                "Launch App in the Microsoft 365 app (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
+            "configurations": [
+                "Launch App in Teams (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Chrome)",
+            "configurations": [
+                "Launch App in Teams (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -110,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true

--- a/templates/ts/api-plugin-from-scratch-oauth/.vscode/launch.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/.vscode/launch.json.tpl
@@ -3,7 +3,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch App in Copilot (Edge)",
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -14,10 +44,11 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Launch App in Copilot (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
@@ -28,27 +59,39 @@
                 "group": "all",
                 "hidden": true
             },
-            "internalConsoleOptions": "neverOpen"
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -65,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
             "configurations": [
-                "Launch App in Copilot (Edge)",
+                "Launch App in the Microsoft 365 app (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in the Microsoft 365 app (Chrome)",
             "configurations": [
-                "Launch App in Copilot (Chrome)",
+                "Launch App in the Microsoft 365 app (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
+            "configurations": [
+                "Launch App in Teams (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Chrome)",
+            "configurations": [
+                "Launch App in Teams (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -110,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true

--- a/templates/ts/api-plugin-from-scratch/.vscode/launch.json.tpl
+++ b/templates/ts/api-plugin-from-scratch/.vscode/launch.json.tpl
@@ -3,6 +3,36 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch App in the Microsoft 365 app (Edge)",
+            "type": "msedge",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
+            "name": "Launch App in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "cascadeTerminateToConfigurations": [
+                "Attach to Backend"
+            ],
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen",
+            "perScriptSourcemaps": "yes"
+        },
+        {
             "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
@@ -33,24 +63,35 @@
             "perScriptSourcemaps": "yes"
         },
         {
-            "name": "Preview in Copilot (Edge)",
+            "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 1
+                "group": "group 2: Teams",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Copilot (Chrome)",
+            "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
-                "group": "remote",
-                "order": 2
+                "group": "group 2: Teams",
+                "order": 5
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in Teams (Desktop)",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "presentation": {
+                "group": "group 2: Teams",
+                "order": 6
             },
             "internalConsoleOptions": "neverOpen"
         },
@@ -67,40 +108,77 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Preview in Teams (Desktop)",
-            "type": "node",
+            "name": "Preview in the Microsoft 365 app (Edge)",
+            "type": "msedge",
             "request": "launch",
-            "preLaunchTask": "Start Teams App in Desktop Client (Remote)",
+            "url": "https://www.office.com/chat?auth=2",
             "presentation": {
-                "group": "remote",
+                "group": "group 1: the Microsoft 365 app",
                 "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Preview in the Microsoft 365 app (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "url": "https://www.office.com/chat?auth=2",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 4
             },
             "internalConsoleOptions": "neverOpen"
         }
     ],
     "compounds": [
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "Debug in the Microsoft 365 app (Edge)",
+            "configurations": [
+                "Launch App in the Microsoft 365 app (Edge)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in the Microsoft 365 app (Chrome)",
+            "configurations": [
+                "Launch App in the Microsoft 365 app (Chrome)",
+                "Attach to Backend"
+            ],
+            "preLaunchTask": "Start Teams App Locally",
+            "presentation": {
+                "group": "group 1: the Microsoft 365 app",
+                "order": 2
+            },
+            "stopAll": true
+        },
+        {
+            "name": "Debug in Teams (Edge)",
             "configurations": [
                 "Launch App in Teams (Edge)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 1
             },
             "stopAll": true
         },
         {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "Debug in Teams (Chrome)",
             "configurations": [
                 "Launch App in Teams (Chrome)",
                 "Attach to Backend"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 2
             },
             "stopAll": true
@@ -112,7 +190,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "all",
+                "group": "group 2: Teams",
                 "order": 3
             },
             "stopAll": true


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29118124

Updated the launch profile for API Plugin templates, added office.com to the launch profile, and set it as the default.|
![Snipaste_2024-08-19_13-43-55](https://github.com/user-attachments/assets/ff1f1ce8-4844-40c3-893a-4078fd9b484f)
![Snipaste_2024-08-19_14-40-57](https://github.com/user-attachments/assets/880c720f-5f81-43f9-832f-2342af24dd4b)
