### PR TITLE
feat: support AAD for API Plugin from scratch templates

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,4 +1,0 @@
-# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
-**/tests/
-*.tests.ts
-**/node_modules/

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,4 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+**/tests/
+*.tests.ts
+**/node_modules/

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1039,7 +1039,11 @@ export function apiAuthQuestion(): SingleSelectQuestion {
       if (inputs[QuestionNames.MeArchitectureType] === MeArchitectureOptions.newApi().id) {
         options.push(ApiAuthOptions.apiKey(), ApiAuthOptions.microsoftEntra());
       } else if (inputs[QuestionNames.ApiPluginType] === ApiPluginStartOptions.newApi().id) {
-        options.push(ApiAuthOptions.apiKey(), ApiAuthOptions.oauth());
+        options.push(
+          ApiAuthOptions.apiKey(),
+          ApiAuthOptions.microsoftEntra(),
+          ApiAuthOptions.oauth()
+        );
       }
       return options;
     },

--- a/packages/fx-core/tests/component/generator/copilotExtensionGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/copilotExtensionGenerator.test.ts
@@ -59,6 +59,13 @@ describe("copilotExtension", async () => {
       info = await generator.getTemplateInfos(context, inputs, ".");
       assert.isTrue(res);
       assert.equal(info.isOk() && info.value[0].templateName, "api-plugin-from-scratch-oauth");
+
+      inputs[QuestionNames.ApiAuth] = ApiAuthOptions.microsoftEntra().id;
+      res = await generator.activate(context, inputs);
+      info = await generator.getTemplateInfos(context, inputs, ".");
+      assert.isTrue(res);
+      assert.equal(info.isOk() && info.value[0].templateName, "api-plugin-from-scratch-oauth");
+
       if (info.isOk()) {
         const filterFn = info.value[0].filterFn;
         assert.isFalse(filterFn?.("repairDeclarativeCopilot.json"));

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -3761,6 +3761,7 @@ describe("scaffold question", () => {
         assert.deepEqual(options, [
           ApiAuthOptions.none(),
           ApiAuthOptions.apiKey(),
+          ApiAuthOptions.microsoftEntra(),
           ApiAuthOptions.oauth(),
         ]);
       }

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1631,7 +1631,7 @@ describe("scaffold question", () => {
           } else if (question.name === QuestionNames.ApiAuth) {
             const select = question as SingleSelectQuestion;
             const options = await select.dynamicOptions!(inputs);
-            assert.isTrue(options.length === 3);
+            assert.isTrue(options.length === 4);
             return ok({ type: "success", result: ApiAuthOptions.none().id });
           } else if (question.name === QuestionNames.ProgrammingLanguage) {
             const select = question as SingleSelectQuestion;
@@ -1686,7 +1686,7 @@ describe("scaffold question", () => {
           } else if (question.name === QuestionNames.ApiAuth) {
             const select = question as SingleSelectQuestion;
             const options = await select.dynamicOptions!(inputs);
-            assert.isTrue(options.length === 3);
+            assert.isTrue(options.length === 4);
             return ok({ type: "success", result: ApiAuthOptions.apiKey().id });
           } else if (question.name === QuestionNames.ProgrammingLanguage) {
             const select = question as SingleSelectQuestion;

--- a/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -20,7 +20,7 @@
         {
             "adminConsentDescription": "Allows Copilot to read repair records on your behalf.",
             "adminConsentDisplayName": "Read repairs",
-            "id": "${{TEAMS_APP_ID}}",
+            "id": "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
             "isEnabled": true,
             "type": "User",
             "userConsentDescription": "Allows Copilot to read repair records.",
@@ -28,6 +28,16 @@
             "value": "repairs_read"
         }
     ],
+{{#isMicrosoftEntra}}
+    "preAuthorizedApplications": [
+        {
+            "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
+            "permissionIds": [
+                "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+            ]
+        }
+    ],
+{{/isMicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -28,7 +28,7 @@
             "value": "repairs_read"
         }
     ],
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     "preAuthorizedApplications": [
         {
             "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
@@ -37,7 +37,7 @@
             ]
         }
     ],
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -69,7 +69,12 @@
       "type": "OpenApi",
       "auth": {
         "type": "OAuthPluginVault",
+{{^isMicrosoftEntra}}
         "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
+{{/isMicrosoftEntra}}
+{{#isMicrosoftEntra}}
+        "reference_id": "${{AADAUTHCODE_CONFIGURATION_ID}}"
+{{/isMicrosoftEntra}}
       },
       "spec": {
         "url": "apiSpecificationFile/repair.dev.yml",

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -69,12 +69,12 @@
       "type": "OpenApi",
       "auth": {
         "type": "OAuthPluginVault",
-{{^isMicrosoftEntra}}
-        "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
-{{/isMicrosoftEntra}}
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
         "reference_id": "${{AADAUTHCODE_CONFIGURATION_ID}}"
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
+        "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
+{{/MicrosoftEntra}}
       },
       "spec": {
         "url": "apiSpecificationFile/repair.dev.yml",

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -9,12 +9,12 @@ servers:
 
 components:
   securitySchemes:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     aadAuthCode:
       type: oauth2
       description: AAD configuration for the repair service      
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -24,7 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -32,12 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
         - aadAuthCode: []
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
         - oAuth2AuthCode: []
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -6,8 +6,15 @@ info:
 servers:
   - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
+
 components:
   securitySchemes:
+{{#isMicrosoftEntra}}
+    aadAuthCode:
+      type: oauth2
+      description: AAD configuration for the repair service      
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -17,6 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
+{{/isMicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -24,7 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
+{{#isMicrosoftEntra}}
+        - aadAuthCode: []
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
         - oAuth2AuthCode: []
+{{/isMicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -3,8 +3,10 @@
 param resourceBaseName string
 param functionAppSKU string
 param aadAppClientId string
+{{^MicrosoftEntra}}
 @secure()
 param aadAppClientSecret string
+{{/MicrosoftEntra}}
 param aadAppTenantId string
 param aadAppOauthAuthorityHost string
 param location string = resourceGroup().location
@@ -52,10 +54,12 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'M365_CLIENT_ID'
           value: aadAppClientId
         }
+{{^MicrosoftEntra}}
         {
           name: 'M365_CLIENT_SECRET'
           value: aadAppClientSecret
         }
+{{/MicrosoftEntra}}
         {
           name: 'M365_TENANT_ID'
           value: aadAppTenantId

--- a/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
@@ -11,9 +11,11 @@
     "aadAppClientId": {
       "value": "${{AAD_APP_CLIENT_ID}}"
     },
+{{^MicrosoftEntra}}
     "aadAppClientSecret": {
       "value": "${{SECRET_AAD_APP_CLIENT_SECRET}}"
     },
+{{/MicrosoftEntra}}
     "aadAppTenantId": {
       "value": "${{AAD_APP_TENANT_ID}}"
     },

--- a/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.6/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.5
+version: v1.6
 
 environmentFolderPath: ./env
 
@@ -17,12 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
       generateClientSecret: false
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       generateClientSecret: true
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -32,9 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
-{{^isMicrosoftEntra}}
+{{^MicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -86,17 +86,18 @@ provision:
 
   - uses: oauth/register
     with:
-{{#isMicrosoftEntra}}
-      name: aadAuth
+{{#MicrosoftEntra}}
+      name: aadAuthCode
+      flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
       clientId: ${{AAD_APP_CLIENT_ID}}
       # Path to OpenAPI description document
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
-      iden
+      identityProvider: MicrosoftEntra
     writeToEnvironmentFile:
       configurationId: AADAUTHCODE_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -106,7 +107,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage

--- a/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -7,7 +7,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsapp provision' is executed
 provision:
-    # Creates a new Microsoft Entra app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
@@ -17,7 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
+{{#isMicrosoftEntra}}
+      generateClientSecret: false
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       generateClientSecret: true
+{{/isMicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -27,7 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
+{{^isMicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
+{{/isMicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -43,7 +50,7 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  - uses: arm/deploy  # Deploy given ARM templates parallelly.
+  - uses: arm/deploy # Deploy given ARM templates parallelly.
     with:
       # AZURE_SUBSCRIPTION_ID is a built-in environment variable,
       # if its value is empty, TeamsFx will prompt you to select a subscription.
@@ -57,7 +64,7 @@ provision:
       # will skip the resource group selection prompt.
       resourceGroupName: ${{AZURE_RESOURCE_GROUP_NAME}}
       templates:
-        - path: ./infra/azure.bicep  # Relative path to this file
+        - path: ./infra/azure.bicep # Relative path to this file
           # Relative path to this yaml file.
           # Placeholders will be replaced with corresponding environment
           # variable before ARM deployment.
@@ -79,6 +86,17 @@ provision:
 
   - uses: oauth/register
     with:
+{{#isMicrosoftEntra}}
+      name: aadAuth
+      appId: ${{TEAMS_APP_ID}}
+      clientId: ${{AAD_APP_CLIENT_ID}}
+      # Path to OpenAPI description document
+      apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
+      iden
+    writeToEnvironmentFile:
+      configurationId: AADAUTHCODE_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -88,6 +106,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -101,7 +120,7 @@ provision:
   - uses: teamsApp/validateAppPackage
     with:
       # Relative path to this file. This is the path for built zip file.
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip     
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Apply the Teams app manifest to an existing Teams app in
   # Teams Developer Portal.

--- a/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
@@ -83,12 +83,14 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | `teamsapp.yml`       | This is the main Teams Toolkit project file. The project file defines two primary things: Properties and configuration Stage definitions.                                                                                                               |
 | `teamsapp.local.yml` | This overrides `teamsapp.yml` with actions that enable local execution and debugging.                                                                                                                                                                   |
 | `aad.manifest.json`  | This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app. |
+{{^isMicrosoftEntra}}
 
 ## How OAuth works in the API plugin
 
 ![oauth-flow](https://github.com/OfficeDev/teams-toolkit/assets/107838226/f074abbe-d9e3-4a46-8e08-feb66b17a539)
 
 > **Note**: The OAuth flow is only functional in remote environments. It cannot be tested in a local environment due to the lack of authentication support in Azure Function core tools.
+{{/isMicrosoftEntra}}
 
 ## Addition information and references
 

--- a/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
@@ -83,14 +83,14 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | `teamsapp.yml`       | This is the main Teams Toolkit project file. The project file defines two primary things: Properties and configuration Stage definitions.                                                                                                               |
 | `teamsapp.local.yml` | This overrides `teamsapp.yml` with actions that enable local execution and debugging.                                                                                                                                                                   |
 | `aad.manifest.json`  | This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app. |
-{{^isMicrosoftEntra}}
+{{^MicrosoftEntra}}
 
 ## How OAuth works in the API plugin
 
 ![oauth-flow](https://github.com/OfficeDev/teams-toolkit/assets/107838226/f074abbe-d9e3-4a46-8e08-feb66b17a539)
 
 > **Note**: The OAuth flow is only functional in remote environments. It cannot be tested in a local environment due to the lack of authentication support in Azure Function core tools.
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 
 ## Addition information and references
 

--- a/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -20,7 +20,7 @@
         {
             "adminConsentDescription": "Allows Copilot to read repair records on your behalf.",
             "adminConsentDisplayName": "Read repairs",
-            "id": "${{TEAMS_APP_ID}}",
+            "id": "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
             "isEnabled": true,
             "type": "User",
             "userConsentDescription": "Allows Copilot to read repair records.",
@@ -28,6 +28,16 @@
             "value": "repairs_read"
         }
     ],
+{{#isMicrosoftEntra}}
+    "preAuthorizedApplications": [
+        {
+            "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
+            "permissionIds": [
+                "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+            ]
+        }
+    ],
+{{/isMicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -28,7 +28,7 @@
             "value": "repairs_read"
         }
     ],
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     "preAuthorizedApplications": [
         {
             "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
@@ -37,7 +37,7 @@
             ]
         }
     ],
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -69,7 +69,12 @@
       "type": "OpenApi",
       "auth": {
         "type": "OAuthPluginVault",
+{{^isMicrosoftEntra}}
         "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
+{{/isMicrosoftEntra}}
+{{#isMicrosoftEntra}}
+        "reference_id": "${{AADAUTHCODE_CONFIGURATION_ID}}"
+{{/isMicrosoftEntra}}
       },
       "spec": {
         "url": "apiSpecificationFile/repair.dev.yml",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -69,12 +69,12 @@
       "type": "OpenApi",
       "auth": {
         "type": "OAuthPluginVault",
-{{^isMicrosoftEntra}}
-        "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
-{{/isMicrosoftEntra}}
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
         "reference_id": "${{AADAUTHCODE_CONFIGURATION_ID}}"
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
+        "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
+{{/MicrosoftEntra}}
       },
       "spec": {
         "url": "apiSpecificationFile/repair.dev.yml",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -9,12 +9,12 @@ servers:
 
 components:
   securitySchemes:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     aadAuthCode:
       type: oauth2
       description: AAD configuration for the repair service      
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -24,7 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -32,12 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
         - aadAuthCode: []
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
         - oAuth2AuthCode: []
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -6,8 +6,15 @@ info:
 servers:
   - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
+
 components:
   securitySchemes:
+{{#isMicrosoftEntra}}
+    aadAuthCode:
+      type: oauth2
+      description: AAD configuration for the repair service      
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -17,6 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
+{{/isMicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -24,7 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
+{{#isMicrosoftEntra}}
+        - aadAuthCode: []
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
         - oAuth2AuthCode: []
+{{/isMicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/js/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -3,13 +3,16 @@
 param resourceBaseName string
 param functionAppSKU string
 param aadAppClientId string
+{{^MicrosoftEntra}}
 @secure()
 param aadAppClientSecret string
+{{/MicrosoftEntra}}
 param aadAppTenantId string
 param aadAppOauthAuthorityHost string
 param location string = resourceGroup().location
 param serverfarmsName string = resourceBaseName
 param functionAppName string = resourceBaseName
+
 
 // Compute resources for Azure Functions
 resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
@@ -51,10 +54,12 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'M365_CLIENT_ID'
           value: aadAppClientId
         }
+{{^MicrosoftEntra}}
         {
           name: 'M365_CLIENT_SECRET'
           value: aadAppClientSecret
         }
+{{/MicrosoftEntra}}
         {
           name: 'M365_TENANT_ID'
           value: aadAppTenantId

--- a/templates/js/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
@@ -11,9 +11,11 @@
     "aadAppClientId": {
       "value": "${{AAD_APP_CLIENT_ID}}"
     },
+{{^MicrosoftEntra}}
     "aadAppClientSecret": {
       "value": "${{SECRET_AAD_APP_CLIENT_SECRET}}"
     },
+{{/MicrosoftEntra}}
     "aadAppTenantId": {
       "value": "${{AAD_APP_TENANT_ID}}"
     },

--- a/templates/js/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.6/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.5
+version: v1.6
 
 environmentFolderPath: ./env
 
@@ -17,12 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
       generateClientSecret: false
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       generateClientSecret: true
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -32,9 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
-{{^isMicrosoftEntra}}
+{{^MicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -86,17 +86,18 @@ provision:
 
   - uses: oauth/register
     with:
-{{#isMicrosoftEntra}}
-      name: aadAuth
+{{#MicrosoftEntra}}
+      name: aadAuthCode
+      flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
       clientId: ${{AAD_APP_CLIENT_ID}}
       # Path to OpenAPI description document
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
-      iden
+      identityProvider: MicrosoftEntra
     writeToEnvironmentFile:
-      configurationId: AADAUTH_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+      configurationId: AADAUTHCODE_CONFIGURATION_ID
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -106,7 +107,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -176,7 +177,7 @@ publish:
   - uses: teamsApp/validateAppPackage
     with:
       # Relative path to this file. This is the path for built zip file.
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip      
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Apply the Teams app manifest to an existing Teams app in
   # Teams Developer Portal.
   # Will use the app id in manifest file to determine which Teams app to update.

--- a/templates/js/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -17,7 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
+{{#isMicrosoftEntra}}
+      generateClientSecret: false
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       generateClientSecret: true
+{{/isMicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -27,7 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
+{{^isMicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
+{{/isMicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -79,6 +86,17 @@ provision:
 
   - uses: oauth/register
     with:
+{{#isMicrosoftEntra}}
+      name: aadAuth
+      appId: ${{TEAMS_APP_ID}}
+      clientId: ${{AAD_APP_CLIENT_ID}}
+      # Path to OpenAPI description document
+      apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
+      iden
+    writeToEnvironmentFile:
+      configurationId: AADAUTH_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -88,6 +106,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -101,7 +120,7 @@ provision:
   - uses: teamsApp/validateAppPackage
     with:
       # Relative path to this file. This is the path for built zip file.
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip      
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Apply the Teams app manifest to an existing Teams app in
   # Teams Developer Portal.

--- a/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
@@ -83,12 +83,14 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | `teamsapp.yml`       | This is the main Teams Toolkit project file. The project file defines two primary things: Properties and configuration Stage definitions.                                                                                                               |
 | `teamsapp.local.yml` | This overrides `teamsapp.yml` with actions that enable local execution and debugging.                                                                                                                                                                   |
 | `aad.manifest.json`  | This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app. |
+{{^isMicrosoftEntra}}
 
 ## How OAuth works in the API plugin
 
 ![oauth-flow](https://github.com/OfficeDev/teams-toolkit/assets/107838226/f074abbe-d9e3-4a46-8e08-feb66b17a539)
 
 > **Note**: The OAuth flow is only functional in remote environments. It cannot be tested in a local environment due to the lack of authentication support in Azure Function core tools.
+{{/isMicrosoftEntra}}
 
 ## Addition information and references
 

--- a/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
@@ -83,14 +83,14 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | `teamsapp.yml`       | This is the main Teams Toolkit project file. The project file defines two primary things: Properties and configuration Stage definitions.                                                                                                               |
 | `teamsapp.local.yml` | This overrides `teamsapp.yml` with actions that enable local execution and debugging.                                                                                                                                                                   |
 | `aad.manifest.json`  | This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app. |
-{{^isMicrosoftEntra}}
+{{^MicrosoftEntra}}
 
 ## How OAuth works in the API plugin
 
 ![oauth-flow](https://github.com/OfficeDev/teams-toolkit/assets/107838226/f074abbe-d9e3-4a46-8e08-feb66b17a539)
 
 > **Note**: The OAuth flow is only functional in remote environments. It cannot be tested in a local environment due to the lack of authentication support in Azure Function core tools.
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 
 ## Addition information and references
 

--- a/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -28,6 +28,16 @@
             "value": "repairs_read"
         }
     ],
+{{#isMicrosoftEntra}}
+    "preAuthorizedApplications": [
+        {
+            "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
+            "permissionIds": [
+                "${{TEAMS_APP_ID}}"
+            ]
+        }
+    ],
+{{/isMicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -28,7 +28,7 @@
             "value": "repairs_read"
         }
     ],
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     "preAuthorizedApplications": [
         {
             "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
@@ -37,7 +37,7 @@
             ]
         }
     ],
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -69,7 +69,12 @@
       "type": "OpenApi",
       "auth": {
         "type": "OAuthPluginVault",
+{{#MicrosoftEntra}}
+        "reference_id": "${{AADAUTHCODE_CONFIGURATION_ID}}"
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
         "reference_id": "${{OAUTH2AUTHCODE_CONFIGURATION_ID}}"
+{{/MicrosoftEntra}}
       },
       "spec": {
         "url": "apiSpecificationFile/repair.dev.yml",

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -9,12 +9,12 @@ servers:
 
 components:
   securitySchemes:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
     aadAuthCode:
       type: oauth2
       description: AAD configuration for the repair service      
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -24,7 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -32,12 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
         - aadAuthCode: []
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
         - oAuth2AuthCode: []
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/apiSpecificationFile/repair.dev.yml.tpl
@@ -6,8 +6,15 @@ info:
 servers:
   - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
+
 components:
   securitySchemes:
+{{#isMicrosoftEntra}}
+    aadAuthCode:
+      type: oauth2
+      description: AAD configuration for the repair service      
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
     oAuth2AuthCode:
       type: oauth2
       description: OAuth configuration for the repair service
@@ -17,7 +24,7 @@ components:
           tokenUrl: https://login.microsoftonline.com/${{AAD_APP_TENANT_ID}}/oauth2/v2.0/token
           scopes:
             api://${{AAD_APP_CLIENT_ID}}/repairs_read: Read repair records
-
+{{/isMicrosoftEntra}}
 paths:
   /repairs:
     get:
@@ -25,7 +32,12 @@ paths:
       summary: List all repairs
       description: Returns a list of repairs with their details and images
       security:
+{{#isMicrosoftEntra}}
+        - aadAuthCode: []
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
         - oAuth2AuthCode: []
+{{/isMicrosoftEntra}}
       parameters:
         - name: assignedTo
           in: query

--- a/templates/ts/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -3,8 +3,10 @@
 param resourceBaseName string
 param functionAppSKU string
 param aadAppClientId string
+{{^MicrosoftEntra}}
 @secure()
 param aadAppClientSecret string
+{{/MicrosoftEntra}}
 param aadAppTenantId string
 param aadAppOauthAuthorityHost string
 param location string = resourceGroup().location
@@ -52,10 +54,12 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'M365_CLIENT_ID'
           value: aadAppClientId
         }
+{{^MicrosoftEntra}}
         {
           name: 'M365_CLIENT_SECRET'
           value: aadAppClientSecret
         }
+{{/MicrosoftEntra}}
         {
           name: 'M365_TENANT_ID'
           value: aadAppTenantId
@@ -82,7 +86,6 @@ resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
       requireAuthentication: true
       unauthenticatedClientAction: 'Return401'
     }
-
     identityProviders: {
       azureActiveDirectory: {
         enabled: true

--- a/templates/ts/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/infra/azure.parameters.json.tpl
@@ -11,9 +11,11 @@
     "aadAppClientId": {
       "value": "${{AAD_APP_CLIENT_ID}}"
     },
+{{^MicrosoftEntra}}
     "aadAppClientSecret": {
       "value": "${{SECRET_AAD_APP_CLIENT_SECRET}}"
     },
+{{/MicrosoftEntra}}
     "aadAppTenantId": {
       "value": "${{AAD_APP_TENANT_ID}}"
     },

--- a/templates/ts/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.6/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.5
+version: v1.6
 
 environmentFolderPath: ./env
 
@@ -17,12 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
-{{#isMicrosoftEntra}}
+{{#MicrosoftEntra}}
       generateClientSecret: false
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       generateClientSecret: true
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -32,9 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
-{{^isMicrosoftEntra}}
+{{^MicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -86,17 +86,18 @@ provision:
 
   - uses: oauth/register
     with:
-{{#isMicrosoftEntra}}
-      name: aadAuth
+{{#MicrosoftEntra}}
+      name: aadAuthCode
+      flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
       clientId: ${{AAD_APP_CLIENT_ID}}
       # Path to OpenAPI description document
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
-      iden
+      identityProvider: MicrosoftEntra
     writeToEnvironmentFile:
-      configurationId: AADAUTH_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
-{{^isMicrosoftEntra}}
+      configurationId: AADAUTHCODE_CONFIGURATION_ID
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -106,7 +107,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
-{{/isMicrosoftEntra}}
+{{/MicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage

--- a/templates/ts/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/teamsapp.yml.tpl
@@ -17,7 +17,12 @@ provision:
       # defined here.
       name: {{appName}}-aad
       # If the value is false, the action will not generate client secret for you
+{{#isMicrosoftEntra}}
+      generateClientSecret: false
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       generateClientSecret: true
+{{/isMicrosoftEntra}}
       # Authenticate users with a Microsoft work or school account in your
       # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
@@ -27,7 +32,9 @@ provision:
       clientId: AAD_APP_CLIENT_ID
       # Environment variable that starts with `SECRET_` will be stored to the
       # .env.{envName}.user environment file
+{{^isMicrosoftEntra}}
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET
+{{/isMicrosoftEntra}}
       objectId: AAD_APP_OBJECT_ID
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
@@ -79,6 +86,17 @@ provision:
 
   - uses: oauth/register
     with:
+{{#isMicrosoftEntra}}
+      name: aadAuth
+      appId: ${{TEAMS_APP_ID}}
+      clientId: ${{AAD_APP_CLIENT_ID}}
+      # Path to OpenAPI description document
+      apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
+      iden
+    writeToEnvironmentFile:
+      configurationId: AADAUTH_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
+{{^isMicrosoftEntra}}
       name: oAuth2AuthCode
       flow: authorizationCode
       appId: ${{TEAMS_APP_ID}}
@@ -88,6 +106,7 @@ provision:
       apiSpecPath: ./appPackage/apiSpecificationFile/repair.${{TEAMSFX_ENV}}.yml
     writeToEnvironmentFile:
       configurationId: OAUTH2AUTHCODE_CONFIGURATION_ID
+{{/isMicrosoftEntra}}
 
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -101,7 +120,7 @@ provision:
   - uses: teamsApp/validateAppPackage
     with:
       # Relative path to this file. This is the path for built zip file.
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip     
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Apply the Teams app manifest to an existing Teams app in
   # Teams Developer Portal.
@@ -162,7 +181,7 @@ publish:
   - uses: teamsApp/validateAppPackage
     with:
       # Relative path to this file. This is the path for built zip file.
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip     
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Apply the Teams app manifest to an existing Teams app in
   # Teams Developer Portal.
   # Will use the app id in manifest file to determine which Teams app to update.


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29077441

- Add a new `Microsoft Entra` authentication option when scaffolding an API Plugin project.
- Since the AAD template is similar to the OAuth one, I would reuse the the `api-plugin-from-scratch-oauth` template folder.
- Based on the OAuth template, add some placeholders to distinguish the different configurations of OAuth and AAD.