### PR TITLE
refactor: generate from api spec

### DIFF
--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -81,7 +81,7 @@ export class FeatureFlags {
   };
   static readonly EnvFileFunc = {
     name: FeatureFlagName.EnvFileFunc,
-    defaultValue: "false", // Set it to true for dogfooding.
+    defaultValue: "true", // Set it to true for dogfooding.
   };
 }
 

--- a/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
@@ -68,7 +68,7 @@ export class ManifestUtils {
     try {
       content = fs.readFileSync(filePath, { encoding: "utf-8" });
     } catch (e) {
-      return err(new ReadFileError(e, "common"));
+      return err(new ReadFileError(e, "ManifestUtils"));
     }
     content = stripBom(content);
     const contentV3 = convertManifestTemplateToV3(content);

--- a/packages/fx-core/src/component/generator/apiSpec/generator.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/generator.ts
@@ -5,13 +5,11 @@
  * @author yuqzho@microsoft.com
  */
 
-import { hooks } from "@feathersjs/hooks/lib";
 import {
   ProjectType,
   SpecParser,
   SpecParserError,
-  ValidationStatus,
-  WarningType,
+  WarningResult,
 } from "@microsoft/m365-spec-parser";
 import {
   AppPackageFolderName,
@@ -25,7 +23,6 @@ import {
   ResponseTemplatesFolderName,
   Result,
   SystemError,
-  UserError,
   Warning,
   err,
   ok,
@@ -33,9 +30,7 @@ import {
 import * as fs from "fs-extra";
 import { merge } from "lodash";
 import path from "path";
-import * as util from "util";
 import { FeatureFlags, featureFlagManager } from "../../../common/featureFlags";
-import { getLocalizedString } from "../../../common/localizeUtils";
 import { isValidHttpUrl } from "../../../common/stringUtils";
 import { assembleError } from "../../../error";
 import {
@@ -47,9 +42,8 @@ import {
   QuestionNames,
 } from "../../../question/constants";
 import { manifestUtils } from "../../driver/teamsApp/utils/ManifestUtils";
-import { ActionContext, ActionExecutionMW } from "../../middleware/actionExecutionMW";
+import { ActionContext } from "../../middleware/actionExecutionMW";
 import { Generator } from "../generator";
-import { TelemetryEvents } from "../spfx/utils/telemetryEvents";
 import { DefaultTemplateGenerator } from "../templates/templateGenerator";
 import { TemplateInfo } from "../templates/templateInfo";
 import {
@@ -59,18 +53,14 @@ import {
   defaultApiSpecJsonFileName,
   defaultApiSpecYamlFileName,
   defaultPluginManifestFileName,
+  generateFromApiSpec,
   generateScaffoldingSummary,
   getEnvName,
-  invalidApiSpecErrorName,
-  isYamlSpecFile,
-  logValidationResults,
-  specParserGenerateResultAllSuccessTelemetryProperty,
-  specParserGenerateResultTelemetryEvent,
-  specParserGenerateResultWarningsTelemetryProperty,
   updateForCustomApi,
 } from "./helper";
 import { copilotGptManifestUtils } from "../../driver/teamsApp/utils/CopilotGptManifestUtils";
 import { declarativeCopilotInstructionFileName } from "../constant";
+import { isYamlFile } from "../../utils/fileOperation";
 
 const defaultDeclarativeCopilotActionId = "action_1";
 // const fromApiSpecComponentName = "copilot-plugin-existing-api";
@@ -100,186 +90,6 @@ function normalizePath(path: string): string {
 export interface OpenAPISpecGeneratorResult {
   warnings?: Warning[];
 }
-
-// TODO: delete class for old generator
-// export class OpenAPISpecGenerator {
-//   @hooks([
-//     ActionExecutionMW({
-//       enableTelemetry: true,
-//       telemetryComponentName: fromApiSpecComponentName,
-//       telemetryEventName: TelemetryEvents.Generate,
-//       errorSource: fromApiSpecComponentName,
-//     }),
-//   ])
-//   public static async generateMe(
-//     context: Context,
-//     inputs: Inputs,
-//     destinationPath: string,
-//     actionContext?: ActionContext
-//   ): Promise<Result<OpenAPISpecGeneratorResult, FxError>> {
-//     const templateName = fromApiSpecTemplateName;
-//     const componentName = fromApiSpecComponentName;
-
-//     merge(actionContext?.telemetryProps, { [telemetryProperties.templateName]: templateName });
-
-//     return await this.generate(
-//       context,
-//       inputs,
-//       destinationPath,
-//       templateName,
-//       componentName,
-//       false,
-//       inputs.apiAuthData
-//     );
-//   }
-
-//   @hooks([
-//     ActionExecutionMW({
-//       enableTelemetry: true,
-//       telemetryComponentName: pluginFromApiSpecComponentName,
-//       telemetryEventName: TelemetryEvents.Generate,
-//       errorSource: pluginFromApiSpecComponentName,
-//     }),
-//   ])
-//   public static async generateCopilotPlugin(
-//     context: Context,
-//     inputs: Inputs,
-//     destinationPath: string,
-//     actionContext?: ActionContext
-//   ): Promise<Result<OpenAPISpecGeneratorResult, FxError>> {
-//     const templateName = apiPluginFromApiSpecTemplateName;
-//     const componentName = fromApiSpecComponentName;
-
-//     merge(actionContext?.telemetryProps, { [telemetryProperties.templateName]: templateName });
-
-//     return await this.generate(
-//       context,
-//       inputs,
-//       destinationPath,
-//       templateName,
-//       componentName,
-//       true,
-//       inputs.apiAuthData
-//     );
-//   }
-
-//   @hooks([
-//     ActionExecutionMW({
-//       enableTelemetry: true,
-//       telemetryComponentName: fromOpenAIPlugincomponentName,
-//       telemetryEventName: TelemetryEvents.Generate,
-//       errorSource: fromOpenAIPlugincomponentName,
-//     }),
-//   ])
-//   public static async generateCustomCopilot(
-//     context: Context,
-//     inputs: Inputs,
-//     destinationPath: string
-//   ): Promise<Result<OpenAPISpecGeneratorResult, FxError>> {
-//     return await this.generate(
-//       context,
-//       inputs,
-//       destinationPath,
-//       forCustomCopilotRagCustomApi,
-//       forCustomCopilotRagCustomApi,
-//       false
-//     );
-//   }
-
-//   private static async generate(
-//     context: Context,
-//     inputs: Inputs,
-//     destinationPath: string,
-//     templateName: string,
-//     componentName: string,
-//     isPlugin: boolean,
-//     authData?: AuthInfo
-//   ): Promise<Result<OpenAPISpecGeneratorResult, FxError>> {
-//     try {
-//       const appName = inputs[QuestionNames.AppName];
-//       const language = inputs[QuestionNames.ProgrammingLanguage];
-//       const safeProjectNameFromVS =
-//         language === "csharp" ? inputs[QuestionNames.SafeProjectName] : undefined;
-//       const type =
-//         templateName === forCustomCopilotRagCustomApi
-//           ? ProjectType.TeamsAi
-//           : isPlugin
-//           ? ProjectType.Copilot
-//           : ProjectType.SME;
-//       let url = inputs[QuestionNames.ApiSpecLocation];
-//       url = url.trim();
-//       let isYaml: boolean;
-//       try {
-//         isYaml = await isYamlSpecFile(url);
-//       } catch (e) {
-//         isYaml = false;
-//       }
-//       const openapiSpecFileName = isYaml ? defaultApiSpecYamlFileName : defaultApiSpecJsonFileName;
-//       if (authData?.authName) {
-//         const envName = getEnvName(authData.authName, authData.authType);
-//         context.templateVariables = Generator.getDefaultVariables(
-//           appName,
-//           safeProjectNameFromVS,
-//           inputs.targetFramework,
-//           inputs.placeProjectFileInSolutionDir === "true",
-//           {
-//             authName: authData.authName,
-//             openapiSpecPath: normalizePath(
-//               path.join(AppPackageFolderName, defaultApiSpecFolderName, openapiSpecFileName)
-//             ),
-//             registrationIdEnvName: envName,
-//             authType: authData.authType,
-//             withPlugin: inputs[QuestionNames.WithPlugin],
-//           }
-//         );
-//       } else {
-//         context.templateVariables = Generator.getDefaultVariables(
-//           appName,
-//           safeProjectNameFromVS,
-//           inputs.targetFramework,
-//           inputs.placeProjectFileInSolutionDir === "true",
-//           withPlugin: inputs[QuestionNames.WithPlugin],
-//         );
-//       }
-
-//       if (templateName != forCustomCopilotRagCustomApi) {
-//         // download template
-//         const templateRes = await Generator.generateTemplate(
-//           context,
-//           destinationPath,
-//           templateName,
-//           language === ProgrammingLanguage.CSharp ? ProgrammingLanguage.CSharp : undefined
-//         );
-//         if (templateRes.isErr()) return err(templateRes.error);
-//       }
-
-//       context.telemetryReporter.sendTelemetryEvent(copilotPluginExistingApiSpecUrlTelemetryEvent, {
-//         [telemetryProperties.isRemoteUrlTelemetryProperty]: isValidHttpUrl(url).toString(),
-//         [telemetryProperties.generateType]: type.toString(),
-//         [telemetryProperties.authType]: authData?.authType ?? "None",
-//       });
-
-//       const newGenerator = new SpecGenerator();
-//       const getTemplateInfosState: any = {};
-//       inputs.getTemplateInfosState = getTemplateInfosState;
-//       getTemplateInfosState.isYaml = isYaml;
-//       getTemplateInfosState.isPlugin = isPlugin;
-//       getTemplateInfosState.templateName = templateName;
-//       getTemplateInfosState.url = url;
-//       getTemplateInfosState.type = type;
-//       const res = await newGenerator.post(context, inputs, destinationPath);
-//       return res;
-//     } catch (e) {
-//       let error: FxError;
-//       if (e instanceof SpecParserError) {
-//         error = convertSpecParserErrorToFxError(e);
-//       } else {
-//         error = assembleError(e);
-//       }
-//       return err(error);
-//     }
-//   }
-// }
 
 interface TemplateInfosState {
   isYaml: boolean;
@@ -375,7 +185,7 @@ export class SpecGenerator extends DefaultTemplateGenerator {
         : ProjectType.SME;
 
     try {
-      getTemplateInfosState.isYaml = await isYamlSpecFile(getTemplateInfosState.url);
+      getTemplateInfosState.isYaml = await isYamlFile(getTemplateInfosState.url);
     } catch (e) {}
 
     const openapiSpecFileName = getTemplateInfosState.isYaml
@@ -464,61 +274,6 @@ export class SpecGenerator extends DefaultTemplateGenerator {
       const getTemplateInfosState = inputs.getTemplateInfosState as TemplateInfosState;
       const isDeclarativeCopilot =
         inputs[QuestionNames.Capabilities] === CapabilityOptions.declarativeCopilot().id;
-      // validate API spec
-      const specParser = new SpecParser(
-        getTemplateInfosState.url,
-        getTemplateInfosState.isPlugin
-          ? {
-              ...copilotPluginParserOptions,
-              isGptPlugin: isDeclarativeCopilot,
-            }
-          : {
-              allowBearerTokenAuth: true, // Currently, API key auth support is actually bearer token auth
-              allowMultipleParameters: true,
-              projectType: getTemplateInfosState.type,
-              allowOauth2: featureFlagManager.getBooleanValue(FeatureFlags.SMEOAuth),
-            }
-      );
-      const validationRes = await specParser.validate();
-      const warnings = validationRes.warnings;
-      const operationIdWarning = warnings.find((w) => w.type === WarningType.OperationIdMissing);
-      const filters = inputs[QuestionNames.ApiOperation] as string[];
-      if (operationIdWarning && operationIdWarning.data) {
-        const apisMissingOperationId = (operationIdWarning.data as string[]).filter((api) =>
-          filters.includes(api)
-        );
-        if (apisMissingOperationId.length > 0) {
-          operationIdWarning.content = util.format(
-            getLocalizedString("core.common.MissingOperationId"),
-            apisMissingOperationId.join(", ")
-          );
-          delete operationIdWarning.data;
-        } else {
-          warnings.splice(warnings.indexOf(operationIdWarning), 1);
-        }
-      }
-
-      const specVersionWarning = warnings.find(
-        (w) => w.type === WarningType.ConvertSwaggerToOpenAPI
-      );
-      if (specVersionWarning) {
-        specVersionWarning.content = ""; // We don't care content of this warning
-      }
-
-      if (validationRes.status === ValidationStatus.Error) {
-        logValidationResults(validationRes.errors, warnings, context, false, true);
-        const errorMessage =
-          inputs.platform === Platform.VSCode
-            ? getLocalizedString(
-                "core.createProjectQuestion.apiSpec.multipleValidationErrors.vscode.message"
-              )
-            : getLocalizedString(
-                "core.createProjectQuestion.apiSpec.multipleValidationErrors.message"
-              );
-        return err(
-          new UserError(this.componentName, invalidApiSpecErrorName, errorMessage, errorMessage)
-        );
-      }
       const manifestPath = path.join(
         destinationPath,
         AppPackageFolderName,
@@ -533,79 +288,47 @@ export class SpecGenerator extends DefaultTemplateGenerator {
         ? defaultApiSpecYamlFileName
         : defaultApiSpecJsonFileName;
       const openapiSpecPath = path.join(apiSpecFolderPath, openapiSpecFileName);
-      // generate files
+
       await fs.ensureDir(apiSpecFolderPath);
 
-      let generateResult;
-      let pluginManifestPath: string | undefined;
-
-      if (getTemplateInfosState.isPlugin) {
-        pluginManifestPath = path.join(
-          destinationPath,
-          AppPackageFolderName,
-          defaultPluginManifestFileName
-        );
-        generateResult = await specParser.generateForCopilot(
-          manifestPath,
-          filters,
-          openapiSpecPath,
-          pluginManifestPath
-        );
-      } else {
-        const responseTemplateFolder = path.join(
-          destinationPath,
-          AppPackageFolderName,
-          ResponseTemplatesFolderName
-        );
-        generateResult = await specParser.generate(
-          manifestPath,
-          filters,
-          openapiSpecPath,
-          getTemplateInfosState.type === ProjectType.TeamsAi ? undefined : responseTemplateFolder
-        );
-      }
-
-      context.telemetryReporter.sendTelemetryEvent(specParserGenerateResultTelemetryEvent, {
-        [telemetryProperties.generateType]: getTemplateInfosState.type.toString(),
-        [specParserGenerateResultAllSuccessTelemetryProperty]: generateResult.allSuccess.toString(),
-        [specParserGenerateResultWarningsTelemetryProperty]: generateResult.warnings
-          .map((w) => w.type.toString() + ": " + w.content)
-          .join(";"),
-      });
-
-      if (generateResult.warnings.length > 0) {
-        generateResult.warnings.find((o) => {
-          if (o.type === WarningType.OperationOnlyContainsOptionalParam) {
-            o.content = ""; // We don't care content of this warning
-          }
-        });
-        warnings.push(...generateResult.warnings);
-      }
-
-      const manifestRes = await manifestUtils._readAppManifest(manifestPath);
-
-      if (manifestRes.isErr()) {
-        return err(manifestRes.error);
-      }
-
-      const teamsManifest = manifestRes.value;
-
-      if (getTemplateInfosState.templateName === forCustomCopilotRagCustomApi) {
-        const specs = await specParser.getFilteredSpecs(filters);
-        const spec = specs[1];
-        try {
-          const language = inputs[QuestionNames.ProgrammingLanguage] as ProgrammingLanguage;
-          await updateForCustomApi(spec, language, destinationPath, openapiSpecFileName);
-        } catch (error: any) {
-          throw new SystemError(
-            this.componentName,
-            failedToUpdateCustomApiTemplateErrorName,
-            error.message,
-            error.message
-          );
+      let warnings: WarningResult[];
+      const pluginManifestPath =
+        getTemplateInfosState.type === ProjectType.Copilot
+          ? path.join(destinationPath, AppPackageFolderName, defaultPluginManifestFileName)
+          : undefined;
+      const responseTemplateFolder =
+        getTemplateInfosState.type !== ProjectType.Copilot
+          ? path.join(destinationPath, AppPackageFolderName, ResponseTemplatesFolderName)
+          : undefined;
+      const specParser = new SpecParser(
+        getTemplateInfosState.url,
+        getTemplateInfosState.type === ProjectType.Copilot
+          ? { ...copilotPluginParserOptions, isGptPlugin: isDeclarativeCopilot }
+          : {
+              allowBearerTokenAuth: true, // Currently, API key auth support is actually bearer token auth
+              allowMultipleParameters: true,
+              projectType: getTemplateInfosState.type,
+              allowOauth2: featureFlagManager.getBooleanValue(FeatureFlags.SMEOAuth),
+            }
+      );
+      const generateResult = await generateFromApiSpec(
+        specParser,
+        manifestPath,
+        inputs,
+        context,
+        this.componentName,
+        getTemplateInfosState.type,
+        {
+          destinationApiSpecFilePath: openapiSpecPath,
+          pluginManifestFilePath: pluginManifestPath,
+          responseTemplateFolder,
         }
+      );
+      if (generateResult.isErr()) {
+        return err(generateResult.error);
+      } else {
+        warnings = generateResult.value.warnings;
       }
-
       if (isDeclarativeCopilot) {
         const gptManifestPath = path.join(
           path.dirname(manifestPath),
@@ -620,6 +343,30 @@ export class SpecGenerator extends DefaultTemplateGenerator {
           return err(addAcionResult.error);
         }
       }
+
+      if (getTemplateInfosState.templateName === forCustomCopilotRagCustomApi) {
+        const specs = await specParser.getFilteredSpecs(inputs[QuestionNames.ApiOperation]);
+        const spec = specs[1];
+        try {
+          const language = inputs[QuestionNames.ProgrammingLanguage] as ProgrammingLanguage;
+          await updateForCustomApi(spec, language, destinationPath, openapiSpecFileName);
+        } catch (error: any) {
+          throw new SystemError(
+            this.componentName,
+            failedToUpdateCustomApiTemplateErrorName,
+            error.message,
+            error.message
+          );
+        }
+      }
+
+      const manifestRes = await manifestUtils._readAppManifest(manifestPath);
+
+      if (manifestRes.isErr()) {
+        return err(manifestRes.error);
+      }
+
+      const teamsManifest = manifestRes.value;
 
       // log warnings
       if (inputs.platform === Platform.CLI || inputs.platform === Platform.VS) {

--- a/packages/fx-core/src/component/generator/apiSpec/generator.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/generator.ts
@@ -297,7 +297,7 @@ export class SpecGenerator extends DefaultTemplateGenerator {
           ? path.join(destinationPath, AppPackageFolderName, defaultPluginManifestFileName)
           : undefined;
       const responseTemplateFolder =
-        getTemplateInfosState.type !== ProjectType.Copilot
+        getTemplateInfosState.type === ProjectType.SME
           ? path.join(destinationPath, AppPackageFolderName, ResponseTemplatesFolderName)
           : undefined;
       const specParser = new SpecParser(

--- a/packages/fx-core/src/component/generator/apiSpec/generator.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/generator.ts
@@ -56,11 +56,11 @@ import {
   generateFromApiSpec,
   generateScaffoldingSummary,
   getEnvName,
+  isYamlFile,
   updateForCustomApi,
 } from "./helper";
 import { copilotGptManifestUtils } from "../../driver/teamsApp/utils/CopilotGptManifestUtils";
 import { declarativeCopilotInstructionFileName } from "../constant";
-import { isYamlFile } from "../../utils/fileOperation";
 
 const defaultDeclarativeCopilotActionId = "action_1";
 // const fromApiSpecComponentName = "copilot-plugin-existing-api";

--- a/packages/fx-core/src/component/generator/apiSpec/generator.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/generator.ts
@@ -56,7 +56,7 @@ import {
   generateFromApiSpec,
   generateScaffoldingSummary,
   getEnvName,
-  isYamlFile,
+  isYamlSpecFile,
   updateForCustomApi,
 } from "./helper";
 import { copilotGptManifestUtils } from "../../driver/teamsApp/utils/CopilotGptManifestUtils";
@@ -185,7 +185,7 @@ export class SpecGenerator extends DefaultTemplateGenerator {
         : ProjectType.SME;
 
     try {
-      getTemplateInfosState.isYaml = await isYamlFile(getTemplateInfosState.url);
+      getTemplateInfosState.isYaml = await isYamlSpecFile(getTemplateInfosState.url);
     } catch (e) {}
 
     const openapiSpecFileName = getTemplateInfosState.isYaml

--- a/packages/fx-core/src/component/generator/apiSpec/generator.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/generator.ts
@@ -48,7 +48,6 @@ import { DefaultTemplateGenerator } from "../templates/templateGenerator";
 import { TemplateInfo } from "../templates/templateInfo";
 import {
   convertSpecParserErrorToFxError,
-  copilotPluginParserOptions,
   defaultApiSpecFolderName,
   defaultApiSpecJsonFileName,
   defaultApiSpecYamlFileName,
@@ -56,6 +55,7 @@ import {
   generateFromApiSpec,
   generateScaffoldingSummary,
   getEnvName,
+  getParserOptions,
   isYamlSpecFile,
   updateForCustomApi,
 } from "./helper";
@@ -302,14 +302,7 @@ export class SpecGenerator extends DefaultTemplateGenerator {
           : undefined;
       const specParser = new SpecParser(
         getTemplateInfosState.url,
-        getTemplateInfosState.type === ProjectType.Copilot
-          ? { ...copilotPluginParserOptions, isGptPlugin: isDeclarativeCopilot }
-          : {
-              allowBearerTokenAuth: true, // Currently, API key auth support is actually bearer token auth
-              allowMultipleParameters: true,
-              projectType: getTemplateInfosState.type,
-              allowOauth2: featureFlagManager.getBooleanValue(FeatureFlags.SMEOAuth),
-            }
+        getParserOptions(getTemplateInfosState.type, isDeclarativeCopilot)
       );
       const generateResult = await generateFromApiSpec(
         specParser,

--- a/packages/fx-core/src/component/generator/apiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/helper.ts
@@ -30,6 +30,7 @@ import {
   Inputs,
   ManifestTemplateFileName,
   ManifestUtil,
+  Platform,
   Result,
   SystemError,
   TeamsAppManifest,
@@ -38,14 +39,13 @@ import {
   err,
   ok,
 } from "@microsoft/teamsfx-api";
-import axios, { AxiosResponse } from "axios";
 import fs from "fs-extra";
 import { OpenAPIV3 } from "openapi-types";
 import { EOL } from "os";
 import path from "path";
 import { FeatureFlags, featureFlagManager } from "../../../common/featureFlags";
 import { getLocalizedString } from "../../../common/localizeUtils";
-import { MissingRequiredInputError } from "../../../error";
+import { assembleError, MissingRequiredInputError } from "../../../error";
 import {
   apiPluginApiSpecOptionId,
   CustomCopilotRagOptions,
@@ -55,7 +55,8 @@ import {
 import { SummaryConstant } from "../../configManager/constant";
 import { manifestUtils } from "../../driver/teamsApp/utils/ManifestUtils";
 import { pluginManifestUtils } from "../../driver/teamsApp/utils/PluginManifestUtils";
-import { sendTelemetryErrorEvent } from "../../../common/telemetry";
+import { sendTelemetryErrorEvent, TelemetryProperty } from "../../../common/telemetry";
+import * as util from "util";
 
 const enum telemetryProperties {
   validationStatus = "validation-status",
@@ -69,6 +70,7 @@ const enum telemetryProperties {
   otherAuthCount = "other-auth-count",
   isFromAddingApi = "is-from-adding-api",
   failedReason = "failed-reason",
+  generateType = "generate-type",
 }
 
 const enum telemetryEvents {
@@ -353,6 +355,111 @@ export async function listPluginExistingOperations(
   const specParser = new SpecParser(apiSpecFilePath, copilotPluginParserOptions);
   const listResult = await specParser.list();
   return listResult.APIs.map((o) => o.api);
+}
+
+interface SpecParserOutputFilePath {
+  destinationApiSpecFilePath: string;
+  pluginManifestFilePath?: string;
+  responseTemplateFolder?: string;
+}
+
+interface SpecParserGenerateResult {
+  warnings: WarningResult[];
+}
+export async function generateFromApiSpec(
+  specParser: SpecParser,
+  teamsManifestPath: string,
+  inputs: Inputs,
+  context: Context,
+  sourceComponent: string,
+  projectType: ProjectType,
+  outputFilePath: SpecParserOutputFilePath
+): Promise<Result<SpecParserGenerateResult, FxError>> {
+  const operations = inputs[QuestionNames.ApiOperation] as string[];
+  const validationRes = await specParser.validate();
+  const warnings = validationRes.warnings;
+  const operationIdWarning = warnings.find((w) => w.type === WarningType.OperationIdMissing);
+
+  if (operationIdWarning && operationIdWarning.data) {
+    const apisMissingOperationId = (operationIdWarning.data as string[]).filter((api) =>
+      operations.includes(api)
+    );
+    if (apisMissingOperationId.length > 0) {
+      operationIdWarning.content = util.format(
+        getLocalizedString("core.common.MissingOperationId"),
+        apisMissingOperationId.join(", ")
+      );
+      delete operationIdWarning.data;
+    } else {
+      warnings.splice(warnings.indexOf(operationIdWarning), 1);
+    }
+  }
+
+  const specVersionWarning = warnings.find((w) => w.type === WarningType.ConvertSwaggerToOpenAPI);
+  if (specVersionWarning) {
+    specVersionWarning.content = ""; // We don't care content of this warning
+  }
+
+  if (validationRes.status === ValidationStatus.Error) {
+    logValidationResults(validationRes.errors, warnings, context, false, true);
+    const errorMessage =
+      inputs.platform === Platform.VSCode
+        ? getLocalizedString(
+            "core.createProjectQuestion.apiSpec.multipleValidationErrors.vscode.message"
+          )
+        : getLocalizedString("core.createProjectQuestion.apiSpec.multipleValidationErrors.message");
+    return err(new UserError(sourceComponent, invalidApiSpecErrorName, errorMessage, errorMessage));
+  }
+
+  try {
+    const generateResult =
+      projectType === ProjectType.Copilot
+        ? await specParser.generateForCopilot(
+            teamsManifestPath,
+            operations,
+            outputFilePath.destinationApiSpecFilePath,
+            outputFilePath.pluginManifestFilePath!
+          )
+        : await specParser.generate(
+            teamsManifestPath,
+            operations,
+            outputFilePath.destinationApiSpecFilePath,
+            projectType === ProjectType.TeamsAi ? undefined : outputFilePath.responseTemplateFolder
+          );
+
+    // Send SpecParser.generate() warnings
+    context.telemetryReporter.sendTelemetryEvent(specParserGenerateResultTelemetryEvent, {
+      [telemetryProperties.generateType]: projectType.toString(),
+      [specParserGenerateResultAllSuccessTelemetryProperty]: generateResult.allSuccess.toString(),
+      [specParserGenerateResultWarningsTelemetryProperty]: generateResult.warnings
+        .map((w) => w.type.toString() + ": " + w.content)
+        .join(";"),
+      [TelemetryProperty.Component]: sourceComponent,
+    });
+
+    if (generateResult.warnings && generateResult.warnings.length > 0) {
+      generateResult.warnings.find((o) => {
+        if (o.type === WarningType.OperationOnlyContainsOptionalParam) {
+          o.content = ""; // We don't care content of this warning
+        }
+      });
+      warnings.push(...generateResult.warnings);
+
+      return ok({
+        warnings,
+      });
+    } else {
+      return ok({ warnings: [] });
+    }
+  } catch (e) {
+    let error: FxError;
+    if (e instanceof SpecParserError) {
+      error = convertSpecParserErrorToFxError(e);
+    } else {
+      error = assembleError(e, sourceComponent);
+    }
+    return err(error);
+  }
 }
 
 export function logValidationResults(
@@ -708,25 +815,6 @@ function formatLengthExceedingErrorMessage(field: string, limit: number): string
 
 export function convertSpecParserErrorToFxError(error: SpecParserError): FxError {
   return new SystemError("SpecParser", error.errorType.toString(), error.message, error.message);
-}
-
-export async function isYamlSpecFile(specPath: string): Promise<boolean> {
-  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
-    return true;
-  } else if (specPath.endsWith(".json")) {
-    return false;
-  }
-  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
-  const fileContent = isRemoteFile
-    ? (await axios.get(specPath)).data
-    : await fs.readFile(specPath, "utf-8");
-
-  try {
-    JSON.parse(fileContent);
-    return false;
-  } catch (error) {
-    return true;
-  }
 }
 
 export function formatValidationErrors(

--- a/packages/fx-core/src/component/generator/apiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/helper.ts
@@ -57,6 +57,7 @@ import { manifestUtils } from "../../driver/teamsApp/utils/ManifestUtils";
 import { pluginManifestUtils } from "../../driver/teamsApp/utils/PluginManifestUtils";
 import { sendTelemetryErrorEvent, TelemetryProperty } from "../../../common/telemetry";
 import * as util from "util";
+import axios from "axios";
 
 const enum telemetryProperties {
   validationStatus = "validation-status",
@@ -536,6 +537,25 @@ export function logValidationResults(
     );
 
   void context.logProvider.info(outputMessage);
+}
+
+export async function isYamlFile(specPath: string): Promise<boolean> {
+  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
+    return true;
+  } else if (specPath.endsWith(".json")) {
+    return false;
+  }
+  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
+  const fileContent = isRemoteFile
+    ? (await axios.get(specPath)).data
+    : await fs.readFile(specPath, "utf-8");
+
+  try {
+    JSON.parse(fileContent);
+    return false;
+  } catch (error) {
+    return true;
+  }
 }
 
 /**

--- a/packages/fx-core/src/component/generator/apiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/helper.ts
@@ -539,25 +539,6 @@ export function logValidationResults(
   void context.logProvider.info(outputMessage);
 }
 
-export async function isYamlFile(specPath: string): Promise<boolean> {
-  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
-    return true;
-  } else if (specPath.endsWith(".json")) {
-    return false;
-  }
-  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
-  const fileContent = isRemoteFile
-    ? (await axios.get(specPath)).data
-    : await fs.readFile(specPath, "utf-8");
-
-  try {
-    JSON.parse(fileContent);
-    return false;
-  } catch (error) {
-    return true;
-  }
-}
-
 /**
  * Generate scaffolding warning summary.
  * @param warnings warnings returned from spec-parser.
@@ -835,6 +816,25 @@ function formatLengthExceedingErrorMessage(field: string, limit: number): string
 
 export function convertSpecParserErrorToFxError(error: SpecParserError): FxError {
   return new SystemError("SpecParser", error.errorType.toString(), error.message, error.message);
+}
+
+export async function isYamlSpecFile(specPath: string): Promise<boolean> {
+  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
+    return true;
+  } else if (specPath.endsWith(".json")) {
+    return false;
+  }
+  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
+  const fileContent = isRemoteFile
+    ? (await axios.get(specPath)).data
+    : await fs.readFile(specPath, "utf-8");
+
+  try {
+    JSON.parse(fileContent);
+    return false;
+  } catch (error) {
+    return true;
+  }
 }
 
 export function formatValidationErrors(

--- a/packages/fx-core/src/component/generator/apiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/helper.ts
@@ -458,13 +458,9 @@ export async function generateFromApiSpec(
         }
       });
       warnings.push(...generateResult.warnings);
-
-      return ok({
-        warnings,
-      });
-    } else {
-      return ok({ warnings: [] });
     }
+
+    return ok({ warnings });
   } catch (e) {
     let error: FxError;
     if (e instanceof SpecParserError) {

--- a/packages/fx-core/src/component/utils/fileOperation.ts
+++ b/packages/fx-core/src/component/utils/fileOperation.ts
@@ -7,6 +7,7 @@ import AdmZip, { EntryHeader } from "adm-zip";
 import { Ignore } from "ignore";
 import path from "path";
 import { CacheFileInUse, DeployEmptyFolderError, ZipFileError } from "../../error/deploy";
+import axios from "axios";
 
 /**
  * Asynchronously zip a folder and return buffer
@@ -107,4 +108,23 @@ export async function forEachFileAndDir(
       .on("error", (err) => reject(err))
       .on("close", () => resolve({}));
   });
+}
+
+export async function isYamlFile(specPath: string): Promise<boolean> {
+  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
+    return true;
+  } else if (specPath.endsWith(".json")) {
+    return false;
+  }
+  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
+  const fileContent = isRemoteFile
+    ? (await axios.get(specPath)).data
+    : await fs.readFile(specPath, "utf-8");
+
+  try {
+    JSON.parse(fileContent);
+    return false;
+  } catch (error) {
+    return true;
+  }
 }

--- a/packages/fx-core/src/component/utils/fileOperation.ts
+++ b/packages/fx-core/src/component/utils/fileOperation.ts
@@ -109,22 +109,3 @@ export async function forEachFileAndDir(
       .on("close", () => resolve({}));
   });
 }
-
-export async function isYamlFile(specPath: string): Promise<boolean> {
-  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
-    return true;
-  } else if (specPath.endsWith(".json")) {
-    return false;
-  }
-  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
-  const fileContent = isRemoteFile
-    ? (await axios.get(specPath)).data
-    : await fs.readFile(specPath, "utf-8");
-
-  try {
-    JSON.parse(fileContent);
-    return false;
-  } catch (error) {
-    return true;
-  }
-}

--- a/packages/fx-core/src/component/utils/fileOperation.ts
+++ b/packages/fx-core/src/component/utils/fileOperation.ts
@@ -7,7 +7,6 @@ import AdmZip, { EntryHeader } from "adm-zip";
 import { Ignore } from "ignore";
 import path from "path";
 import { CacheFileInUse, DeployEmptyFolderError, ZipFileError } from "../../error/deploy";
-import axios from "axios";
 
 /**
  * Asynchronously zip a folder and return buffer

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -106,7 +106,7 @@ import {
   defaultPluginManifestFileName,
   generateFromApiSpec,
   generateScaffoldingSummary,
-  isYamlFile,
+  isYamlSpecFile,
   listOperations,
   listPluginExistingOperations,
 } from "../component/generator/apiSpec/helper";
@@ -1899,7 +1899,7 @@ export class FxCore {
     // generate file path
     let isYaml: boolean;
     try {
-      isYaml = await isYamlFile(url);
+      isYaml = await isYamlSpecFile(url);
     } catch (e) {
       isYaml = false;
     }

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1610,40 +1610,39 @@ export class FxCore {
       url,
       getParserOptions(isPlugin ? ProjectType.Copilot : ProjectType.SME)
     );
-
-    const listResult = await specParser.list();
-    const apiResultList = listResult.APIs.filter((value) => value.isValid);
-
-    let existingOperations: string[];
-    let outputApiSpecPath: string;
-    if (isPlugin) {
-      if (!inputs[QuestionNames.DestinationApiSpecFilePath]) {
-        return err(new MissingRequiredInputError(QuestionNames.DestinationApiSpecFilePath));
-      }
-      outputApiSpecPath = inputs[QuestionNames.DestinationApiSpecFilePath];
-      existingOperations = await listPluginExistingOperations(
-        manifestRes.value,
-        manifestPath,
-        inputs[QuestionNames.DestinationApiSpecFilePath]
-      );
-    } else {
-      const existingOperationIds = manifestUtils.getOperationIds(manifestRes.value);
-      existingOperations = apiResultList
-        .filter((operation) => existingOperationIds.includes(operation.operationId))
-        .map((operation) => operation.api);
-      const apiSpecificationFile = manifestRes.value.composeExtensions![0].apiSpecificationFile;
-      outputApiSpecPath = path.join(path.dirname(manifestPath), apiSpecificationFile!);
-    }
-
-    const operations = [...existingOperations, ...newOperations];
-
-    const adaptiveCardFolder = path.join(
-      inputs.projectPath!,
-      AppPackageFolderName,
-      ResponseTemplatesFolderName
-    );
-
     try {
+      const listResult = await specParser.list();
+      const apiResultList = listResult.APIs.filter((value) => value.isValid);
+
+      let existingOperations: string[];
+      let outputApiSpecPath: string;
+      if (isPlugin) {
+        if (!inputs[QuestionNames.DestinationApiSpecFilePath]) {
+          return err(new MissingRequiredInputError(QuestionNames.DestinationApiSpecFilePath));
+        }
+        outputApiSpecPath = inputs[QuestionNames.DestinationApiSpecFilePath];
+        existingOperations = await listPluginExistingOperations(
+          manifestRes.value,
+          manifestPath,
+          inputs[QuestionNames.DestinationApiSpecFilePath]
+        );
+      } else {
+        const existingOperationIds = manifestUtils.getOperationIds(manifestRes.value);
+        existingOperations = apiResultList
+          .filter((operation) => existingOperationIds.includes(operation.operationId))
+          .map((operation) => operation.api);
+        const apiSpecificationFile = manifestRes.value.composeExtensions![0].apiSpecificationFile;
+        outputApiSpecPath = path.join(path.dirname(manifestPath), apiSpecificationFile!);
+      }
+
+      const operations = [...existingOperations, ...newOperations];
+
+      const adaptiveCardFolder = path.join(
+        inputs.projectPath!,
+        AppPackageFolderName,
+        ResponseTemplatesFolderName
+      );
+
       const authNames: Set<string> = new Set();
       const serverUrls: Set<string> = new Set();
       let authScheme: AuthType | undefined = undefined;

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -106,11 +106,9 @@ import {
   defaultPluginManifestFileName,
   generateFromApiSpec,
   generateScaffoldingSummary,
+  isYamlFile,
   listOperations,
   listPluginExistingOperations,
-  specParserGenerateResultAllSuccessTelemetryProperty,
-  specParserGenerateResultTelemetryEvent,
-  specParserGenerateResultWarningsTelemetryProperty,
 } from "../component/generator/apiSpec/helper";
 import { LaunchHelper } from "../component/m365/launchHelper";
 import { EnvLoaderMW, EnvWriterMW } from "../component/middleware/envMW";
@@ -167,7 +165,6 @@ import { PackageService } from "../component/m365/packageService";
 import { MosServiceEndpoint, MosServiceScope } from "../component/m365/serviceConstant";
 import { teamsDevPortalClient } from "../client/teamsDevPortalClient";
 import { generateDriverContext } from "../common/utils";
-import { isYamlFile } from "../component/utils/fileOperation";
 
 export class FxCore {
   constructor(tools: Tools) {

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -99,13 +99,13 @@ import "../component/feature/sso";
 import { SSO } from "../component/feature/sso";
 import {
   convertSpecParserErrorToFxError,
-  copilotPluginParserOptions,
   defaultApiSpecFolderName,
   defaultApiSpecJsonFileName,
   defaultApiSpecYamlFileName,
   defaultPluginManifestFileName,
   generateFromApiSpec,
   generateScaffoldingSummary,
+  getParserOptions,
   isYamlSpecFile,
   listOperations,
   listPluginExistingOperations,
@@ -1608,12 +1608,7 @@ export class FxCore {
     // Merge existing operations in manifest.json
     const specParser = new SpecParser(
       url,
-      isPlugin
-        ? copilotPluginParserOptions
-        : {
-            allowBearerTokenAuth: true, // Currently, API key auth support is actually bearer token auth
-            allowMultipleParameters: true,
-          }
+      getParserOptions(isPlugin ? ProjectType.Copilot : ProjectType.SME)
     );
 
     const listResult = await specParser.list();
@@ -1925,7 +1920,7 @@ export class FxCore {
     }
     const pluginManifestFilePath = path.join(appPackageFolder, pluginManifestName);
 
-    const specParser = new SpecParser(url, { ...copilotPluginParserOptions, isGptPlugin: true });
+    const specParser = new SpecParser(url, getParserOptions(ProjectType.Copilot, true));
     const generateRes = await generateFromApiSpec(
       specParser,
       manifestPath,

--- a/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
@@ -42,7 +42,7 @@ import * as CopilotPluginHelper from "../../../src/component/generator/apiSpec/h
 import {
   formatValidationErrors,
   generateScaffoldingSummary,
-  isYamlSpecFile,
+  isYamlFile,
   listPluginExistingOperations,
 } from "../../../src/component/generator/apiSpec/helper";
 import {
@@ -327,35 +327,35 @@ describe("generateScaffoldingSummary", async () => {
   });
 });
 
-describe("isYamlSpecFile", () => {
+describe("isYamlFile", () => {
   afterEach(() => {
     sinon.restore();
   });
   it("should return false for a valid JSON file", async () => {
-    const result = await isYamlSpecFile("test.json");
+    const result = await isYamlFile("test.json");
     expect(result).to.be.false;
   });
 
   it("should return true for an yaml file", async () => {
-    const result = await isYamlSpecFile("test.yaml");
+    const result = await isYamlFile("test.yaml");
     expect(result).to.be.true;
   });
 
   it("should handle local json files", async () => {
     const readFileStub = sinon.stub(fs, "readFile").resolves('{"name": "test"}' as any);
-    const result = await isYamlSpecFile("path/to/localfile");
+    const result = await isYamlFile("path/to/localfile");
     expect(result).to.be.false;
   });
 
   it("should handle remote files", async () => {
     const axiosStub = sinon.stub(axios, "get").resolves({ data: '{"name": "test"}' });
-    const result = await isYamlSpecFile("http://example.com/remotefile");
+    const result = await isYamlFile("http://example.com/remotefile");
     expect(result).to.be.false;
   });
 
   it("should return true if it is a yaml file", async () => {
     const readFileStub = sinon.stub(fs, "readFile").resolves("openapi: 3.0.0" as any);
-    const result = await isYamlSpecFile("path/to/localfile");
+    const result = await isYamlFile("path/to/localfile");
     expect(result).to.be.true;
   });
 });
@@ -1502,7 +1502,7 @@ describe("SpecGenerator", async () => {
       };
       inputs[QuestionNames.ApiSpecLocation] = "test.yaml";
       inputs.apiAuthData = { serverUrl: "https://test.com", authName: "test", authType: "apiKey" };
-      sandbox.stub(CopilotPluginHelper, "isYamlSpecFile").throws();
+      sandbox.stub(CopilotPluginHelper, "isYamlFile").throws();
       const res = await generator.getTemplateInfos(context, inputs, ".", { telemetryProps: {} });
       assert.isTrue(res.isOk());
       if (res.isOk()) {

--- a/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
@@ -42,7 +42,7 @@ import * as CopilotPluginHelper from "../../../src/component/generator/apiSpec/h
 import {
   formatValidationErrors,
   generateScaffoldingSummary,
-  isYamlFile,
+  isYamlSpecFile,
   listPluginExistingOperations,
 } from "../../../src/component/generator/apiSpec/helper";
 import {
@@ -332,30 +332,30 @@ describe("isYamlFile", () => {
     sinon.restore();
   });
   it("should return false for a valid JSON file", async () => {
-    const result = await isYamlFile("test.json");
+    const result = await isYamlSpecFile("test.json");
     expect(result).to.be.false;
   });
 
   it("should return true for an yaml file", async () => {
-    const result = await isYamlFile("test.yaml");
+    const result = await isYamlSpecFile("test.yaml");
     expect(result).to.be.true;
   });
 
   it("should handle local json files", async () => {
     const readFileStub = sinon.stub(fs, "readFile").resolves('{"name": "test"}' as any);
-    const result = await isYamlFile("path/to/localfile");
+    const result = await isYamlSpecFile("path/to/localfile");
     expect(result).to.be.false;
   });
 
   it("should handle remote files", async () => {
     const axiosStub = sinon.stub(axios, "get").resolves({ data: '{"name": "test"}' });
-    const result = await isYamlFile("http://example.com/remotefile");
+    const result = await isYamlSpecFile("http://example.com/remotefile");
     expect(result).to.be.false;
   });
 
   it("should return true if it is a yaml file", async () => {
     const readFileStub = sinon.stub(fs, "readFile").resolves("openapi: 3.0.0" as any);
-    const result = await isYamlFile("path/to/localfile");
+    const result = await isYamlSpecFile("path/to/localfile");
     expect(result).to.be.true;
   });
 });
@@ -1502,7 +1502,7 @@ describe("SpecGenerator", async () => {
       };
       inputs[QuestionNames.ApiSpecLocation] = "test.yaml";
       inputs.apiAuthData = { serverUrl: "https://test.com", authName: "test", authType: "apiKey" };
-      sandbox.stub(CopilotPluginHelper, "isYamlFile").throws();
+      sandbox.stub(CopilotPluginHelper, "isYamlSpecFile").throws();
       const res = await generator.getTemplateInfos(context, inputs, ".", { telemetryProps: {} });
       assert.isTrue(res.isOk());
       if (res.isOk()) {

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -2165,6 +2165,11 @@ describe("copilotPlugin", async () => {
       warnings: [],
       allSuccess: true,
     });
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
@@ -2217,6 +2222,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(pluginGeneratorHelper, "generateScaffoldingSummary").resolves("");
@@ -2275,6 +2285,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(manifestUtils, "getPluginFilePath").resolves(ok("ai-plugin.json"));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
@@ -2478,6 +2493,11 @@ describe("copilotPlugin", async () => {
       warnings: [],
       allSuccess: true,
     });
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
@@ -2552,6 +2572,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -2641,6 +2666,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     const teamsappObject = {
@@ -2720,6 +2750,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     const teamsappObject = {
@@ -2797,6 +2832,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(SpecParser.prototype, "generate").resolves({
       warnings: [],
       allSuccess: true,
+    });
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
@@ -2887,6 +2927,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -3000,6 +3045,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -3097,6 +3147,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -3237,6 +3292,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     const teamsappObject = {
       provision: [
         {
@@ -3344,6 +3404,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const teamsappObject = {
       provision: [
@@ -3493,6 +3558,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     const teamsappObject = {
       provision: [
         {
@@ -3635,6 +3705,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     const teamsappObject = {
       provision: [
         {
@@ -3782,6 +3857,11 @@ describe("copilotPlugin", async () => {
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     const teamsappObject = {
       provision: [
         {
@@ -3930,6 +4010,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -4066,6 +4151,11 @@ describe("copilotPlugin", async () => {
       allSuccess: true,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));
@@ -4209,6 +4299,11 @@ describe("copilotPlugin", async () => {
       allSuccess: false,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(pluginGeneratorHelper, "generateScaffoldingSummary").resolves("warning message");
@@ -4280,6 +4375,11 @@ describe("copilotPlugin", async () => {
       allSuccess: false,
     });
     sinon.stub(SpecParser.prototype, "list").resolves(listResult);
+    sinon.stub(SpecParser.prototype, "validate").resolves({
+      warnings: [],
+      status: ValidationStatus.Valid,
+      errors: [],
+    });
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     sinon.stub(tools.ui, "showMessage").resolves(ok("Add"));

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -4769,10 +4769,7 @@ describe("addPlugin", async () => {
       .resolves(ok({} as DeclarativeCopilotManifestSchema));
 
     const core = new FxCore(tools);
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").resolves({
-      warnings: [],
-      allSuccess: true,
-    });
+    sandbox.stub(CopilotPluginHelper, "generateFromApiSpec").resolves(ok({ warnings: [] }));
 
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const result = await core.addPlugin(inputs);
@@ -4832,10 +4829,7 @@ describe("addPlugin", async () => {
       .resolves(ok({} as DeclarativeCopilotManifestSchema));
 
     const core = new FxCore(tools);
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").resolves({
-      warnings: [],
-      allSuccess: true,
-    });
+    sandbox.stub(CopilotPluginHelper, "generateFromApiSpec").resolves(ok({ warnings: [] }));
 
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const result = await core.addPlugin(inputs);
@@ -4895,10 +4889,7 @@ describe("addPlugin", async () => {
       .resolves(ok({} as DeclarativeCopilotManifestSchema));
 
     const core = new FxCore(tools);
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").resolves({
-      warnings: [{ type: WarningType.OperationOnlyContainsOptionalParam, content: "fakeMessage" }],
-      allSuccess: true,
-    });
+    sandbox.stub(CopilotPluginHelper, "generateFromApiSpec").resolves(ok({ warnings: [] }));
 
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const result = await core.addPlugin(inputs);
@@ -5069,47 +5060,6 @@ describe("addPlugin", async () => {
     }
   });
 
-  it("error: generateForCopilot exception", async () => {
-    const appName = await mockV3Project();
-    const inputs: Inputs = {
-      platform: Platform.VSCode,
-      [QuestionNames.Folder]: os.tmpdir(),
-      [QuestionNames.TeamsAppManifestFilePath]: "manifest.json",
-      [QuestionNames.ApiSpecLocation]: "test.json",
-      [QuestionNames.ApiOperation]: ["GET /user/{userId}"],
-      [QuestionNames.PluginAvailability]: PluginAvailabilityOptions.copilotPluginAndAction().id,
-      projectPath: path.join(os.tmpdir(), appName),
-    };
-    const manifest = new TeamsAppManifest();
-    manifest.copilotExtensions = {
-      declarativeCopilots: [
-        {
-          file: "test1.json",
-          id: "action_1",
-        },
-      ],
-    };
-    sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi_1.json")) {
-        return false;
-      }
-      if (path.endsWith("ai-plugin_1.json")) {
-        return false;
-      }
-      return true;
-    });
-    sandbox.stub(validationUtils, "validateInputs").resolves(undefined);
-    sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
-    sandbox
-      .stub(copilotGptManifestUtils, "readCopilotGptManifestFile")
-      .resolves(ok({} as DeclarativeCopilotManifestSchema));
-    sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").throws(new Error("fakeError"));
-    const core = new FxCore(tools);
-    const result = await core.addPlugin(inputs);
-    assert.isTrue(result.isErr());
-  });
-
   it("error: generateForCopilot error", async () => {
     const appName = await mockV3Project();
     const inputs: Inputs = {
@@ -5146,8 +5096,8 @@ describe("addPlugin", async () => {
       .resolves(ok({} as DeclarativeCopilotManifestSchema));
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     sandbox
-      .stub(SpecParser.prototype, "generateForCopilot")
-      .throws(new SpecParserError("fakeError", ErrorType.SpecNotValid));
+      .stub(CopilotPluginHelper, "generateFromApiSpec")
+      .resolves(err(new SystemError("", "", "", "")));
     const core = new FxCore(tools);
     const result = await core.addPlugin(inputs);
     assert.isTrue(result.isErr());
@@ -5196,10 +5146,7 @@ describe("addPlugin", async () => {
       .resolves(ok({} as DeclarativeCopilotManifestSchema));
 
     const core = new FxCore(tools);
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").resolves({
-      warnings: [],
-      allSuccess: true,
-    });
+    sandbox.stub(CopilotPluginHelper, "generateFromApiSpec").resolves(ok({ warnings: [] }));
 
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const result = await core.addPlugin(inputs);
@@ -5252,10 +5199,7 @@ describe("addPlugin", async () => {
       .resolves(err(new SystemError("addActionError", "addActionError", "", "")));
 
     const core = new FxCore(tools);
-    sandbox.stub(SpecParser.prototype, "generateForCopilot").resolves({
-      warnings: [],
-      allSuccess: true,
-    });
+    sandbox.stub(CopilotPluginHelper, "generateFromApiSpec").resolves(ok({ warnings: [] }));
 
     sandbox.stub(tools.ui, "showMessage").resolves(ok("Add"));
     const result = await core.addPlugin(inputs);


### PR DESCRIPTION
E2E: https://github.com/OfficeDev/teams-toolkit/actions/runs/10507081159
Moved some common parts of generating from api spec into a new common function so that the behavior and telemetry will be consistent whenever need to generate from an OpenAPI spec.

Also include a small change to enable FILE feature flag in this PR.