### PR TITLE
fix: fix python env load

### DIFF
--- a/templates/python/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -55,9 +55,11 @@ Before running or debugging your bot, please follow these steps to setup your ow
 {{/useAzureOpenAI}}
 
 {{#useOpenAI}}
-1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following key.
+1. Please config the following key in `./src/utils/creator.py`.
    ```
-   OPENAI_API_KEY=<your-openai-api-key>
+   config = {
+      'OPENAI_API_KEY': '<your-openai-api-key>'
+   }
    ```
    Run command `python src/utils/creator.py`.
    ```
@@ -79,11 +81,13 @@ Before running or debugging your bot, please follow these steps to setup your ow
    ```
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
-1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following keys.
+1. Please config the following keys in `./src/utils/creator.py`.
    ```
-   AZURE_OPENAI_API_KEY=<your-azure-openai-api-key>
-   AZURE_OPENAI_ENDPOINT=<your-azure-openai-endpoint>
-   AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<your-azure-openai-model-delopyment-name>
+   config = {
+      'AZURE_OPENAI_API_KEY': '<your-azure-openai-api-key>',
+      'AZURE_OPENAI_ENDPOINT': '<your-azure-openai-endpoint>',
+      'AZURE_OPENAI_MODEL_DEPLOYMENT_NAME': '<your-azure-openai-model-deployment-name>'
+   }
    ```
    Run command `python src/utils/creator.py`.
    ```

--- a/templates/python/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -55,7 +55,11 @@ Before running or debugging your bot, please follow these steps to setup your ow
 {{/useAzureOpenAI}}
 
 {{#useOpenAI}}
-1. Run command `python src/utils/creator.py`. Remember to fill in your **OpenAI key** in *env/.env.local.user* first.
+1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following key.
+   ```
+   OPENAI_API_KEY=<your-openai-api-key>
+   ```
+   Run command `python src/utils/creator.py`.
    ```
    > python src/utils/creator.py
    ```
@@ -75,7 +79,13 @@ Before running or debugging your bot, please follow these steps to setup your ow
    ```
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
-1. Run command `python src/utils/creator.py`. Remember to fill in your **Azure OpenAI key** in *env/.env.local.user* first.
+1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following keys.
+   ```
+   AZURE_OPENAI_API_KEY=<your-azure-openai-api-key>
+   AZURE_OPENAI_ENDPOINT=<your-azure-openai-endpoint>
+   AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<your-azure-openai-model-delopyment-name>
+   ```
+   Run command `python src/utils/creator.py`.
    ```
    > python src/utils/creator.py
    ```

--- a/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
@@ -17,6 +17,7 @@ config = {
     'AZURE_OPENAI_ENDPOINT': '<your-azure-openai-endpoint>',
     'AZURE_OPENAI_MODEL_DEPLOYMENT_NAME': '<your-azure-openai-model-deployment-name>'
 }
+{{/useAzureOpenAI}}
 
 async def main():
     options = AssistantCreateParams(

--- a/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
@@ -6,7 +6,17 @@ from openai.types.shared_params import FunctionDefinition
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/.env', override=True)
+{{#useOpenAI}}
+config = {
+    'OPENAI_API_KEY': '<your-openai-api-key>'
+}
+{{/useOpenAI}}
+{{#useAzureOpenAI}}
+config = {
+    'AZURE_OPENAI_API_KEY': '<your-azure-openai-api-key>',
+    'AZURE_OPENAI_ENDPOINT': '<your-azure-openai-endpoint>',
+    'AZURE_OPENAI_MODEL_DEPLOYMENT_NAME': '<your-azure-openai-model-deployment-name>'
+}
 
 async def main():
     options = AssistantCreateParams(
@@ -63,19 +73,19 @@ async def main():
         model="gpt-3.5-turbo",
         {{/useOpenAI}}
         {{#useAzureOpenAI}}
-        model=os.getenv("AZURE_OPENAI_MODEL_DEPLOYMENT_NAME"),
+        model=config['AZURE_OPENAI_MODEL_DEPLOYMENT_NAME'],
         {{/useAzureOpenAI}}
     )
 
     {{#useOpenAI}}
-    assistant = await AssistantsPlanner.create_assistant(api_key=os.getenv("OPENAI_API_KEY"), api_version="", organization="", endpoint="", request=options)
+    assistant = await AssistantsPlanner.create_assistant(api_key=config['OPENAI_API_KEY'], api_version="", organization="", endpoint="", request=options)
     {{/useOpenAI}}
     {{#useAzureOpenAI}}
     assistant = await AssistantsPlanner.create_assistant(
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"), 
+        api_key=config['AZURE_OPENAI_API_KEY'], 
         api_version="", 
         organization="", 
-        endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"), 
+        endpoint=config['AZURE_OPENAI_ENDPOINT'], 
         request=options
     )
     {{/useAzureOpenAI}}

--- a/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
@@ -6,7 +6,7 @@ from openai.types.shared_params import FunctionDefinition
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/env/.env.local.user', override=True)
+load_dotenv(f'{os.getcwd()}/.env', override=True)
 
 async def main():
     options = AssistantCreateParams(
@@ -68,11 +68,11 @@ async def main():
     )
 
     {{#useOpenAI}}
-    assistant = await AssistantsPlanner.create_assistant(api_key=os.getenv("SECRET_OPENAI_API_KEY"), api_version="", organization="", endpoint="", request=options)
+    assistant = await AssistantsPlanner.create_assistant(api_key=os.getenv("OPENAI_API_KEY"), api_version="", organization="", endpoint="", request=options)
     {{/useOpenAI}}
     {{#useAzureOpenAI}}
     assistant = await AssistantsPlanner.create_assistant(
-        api_key=os.getenv("SECRET_AZURE_OPENAI_API_KEY"), 
+        api_key=os.getenv("AZURE_OPENAI_API_KEY"), 
         api_version="", 
         organization="", 
         endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"), 

--- a/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/src/utils/creator.py.tpl
@@ -4,8 +4,6 @@ from openai.types.beta import AssistantCreateParams
 from openai.types.beta.function_tool_param import FunctionToolParam
 from openai.types.shared_params import FunctionDefinition
 
-from dotenv import load_dotenv
-
 {{#useOpenAI}}
 config = {
     'OPENAI_API_KEY': '<your-openai-api-key>'

--- a/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -36,7 +36,23 @@ This app template also demonstrates usage of techniques like:
 1. In file *env/.env.local.user*, fill in your Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT`.
 
 ### Setting up index and documents
-1. Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT` are loaded from *env/.env.local.user*. Please make sure you have already configured them.
+1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following keys.
+{{#useOpenAI}}
+    ```
+    OPENAI_API_KEY=
+    AZURE_SEARCH_KEY=
+    AZURE_SEARCH_ENDPOINT=
+    ```
+{{/useOpenAI}}
+{{#useAzureOpenAI}}
+    ```
+    AZURE_OPENAI_API_KEY=
+    AZURE_OPENAI_ENDPOINT=
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT=
+    AZURE_SEARCH_KEY=
+    AZURE_SEARCH_ENDPOINT=
+    ```
+{{/useAzureOpenAI}}
 1. Use command `python src/indexers/setup.py` to create index and upload documents in `src/indexers/data`.
 1. You will see the following information indicated the success of setup:
     ```

--- a/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -36,23 +36,28 @@ This app template also demonstrates usage of techniques like:
 1. In file *env/.env.local.user*, fill in your Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT`.
 
 ### Setting up index and documents
-1. Necessary keys will be loaded from *./.env*. Please create a file *./.env* and fill in the following keys.
+1. Please config the following keys in `./src/indexers/setup.py`.
 {{#useOpenAI}}
     ```
-    OPENAI_API_KEY=
-    AZURE_SEARCH_KEY=
-    AZURE_SEARCH_ENDPOINT=
+    config = {
+        'OPENAI_API_KEY': '<your-openai-api-key>',
+        'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+        'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+    }
     ```
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
     ```
-    AZURE_OPENAI_API_KEY=
-    AZURE_OPENAI_ENDPOINT=
-    AZURE_OPENAI_EMBEDDING_DEPLOYMENT=
-    AZURE_SEARCH_KEY=
-    AZURE_SEARCH_ENDPOINT=
+    config = {
+        'AZURE_OPENAI_API_KEY': '<your-azure-openai-api-key>',
+        'AZURE_OPENAI_ENDPOINT': '<your-azure-openai-endpoint>',
+        'AZURE_OPENAI_EMBEDDING_DEPLOYMENT': '<your-azure-openai-embedding-deployment>',
+        'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+        'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+    }
     ```
 {{/useAzureOpenAI}}
+
 1. Use command `python src/indexers/setup.py` to create index and upload documents in `src/indexers/data`.
 1. You will see the following information indicated the success of setup:
     ```
@@ -60,7 +65,13 @@ This app template also demonstrates usage of techniques like:
     Upload new documents succeeded. If they do not exist, wait for several seconds...
     setup finished
     ```
-1. Once you're done using the sample it's good practice to delete the index. You can do so with the command `python src/indexers/delete.py`.
+1. Once you're done using the sample it's good practice to delete the index. You can do so with the command `python src/indexers/delete.py`. Please configure the following keys in `./src/indexers/delete.py`.
+    ```
+    config = {
+        'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+        'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+    }
+    ```
 
 ### Conversation with bot
 1. Select the Teams Toolkit icon on the left in the VS Code toolbar.

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
@@ -4,15 +4,18 @@ from azure.search.documents.indexes import SearchIndexClient
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/.env', override=True)
+config = {
+    'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+    'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+}
 
 def delete_index(client: SearchIndexClient, name: str):
     client.delete_index(name)
     print(f"Index {name} deleted")
 
 index = 'contoso-electronics'
-search_api_key = os.getenv('AZURE_SEARCH_KEY')
-search_api_endpoint = os.getenv('AZURE_SEARCH_ENDPOINT')
+search_api_key = config['AZURE_SEARCH_KEY']
+search_api_endpoint = config['AZURE_SEARCH_ENDPOINT']
 credentials = AzureKeyCredential(search_api_key)
 
 search_index_client = SearchIndexClient(search_api_endpoint, credentials)

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
@@ -2,8 +2,6 @@ import os
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.indexes import SearchIndexClient
 
-from dotenv import load_dotenv
-
 config = {
     'AZURE_SEARCH_KEY': '<your-azure-search-key>',
     'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py
@@ -4,14 +4,14 @@ from azure.search.documents.indexes import SearchIndexClient
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/env/.env.local.user', override=True)
+load_dotenv(f'{os.getcwd()}/.env', override=True)
 
 def delete_index(client: SearchIndexClient, name: str):
     client.delete_index(name)
     print(f"Index {name} deleted")
 
 index = 'contoso-electronics'
-search_api_key = os.getenv('SECRET_AZURE_SEARCH_KEY')
+search_api_key = os.getenv('AZURE_SEARCH_KEY')
 search_api_endpoint = os.getenv('AZURE_SEARCH_ENDPOINT')
 credentials = AzureKeyCredential(search_api_key)
 

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
@@ -29,7 +29,21 @@ from get_data import get_doc_data
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/.env', override=True)
+{{#useOpenAI}}
+config = {
+    'OPENAI_API_KEY': '<your-openai-api-key>',
+    'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+    'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+}
+{{/useOpenAI}}
+{{#useAzureOpenAI}}
+config = {
+    'AZURE_OPENAI_API_KEY': '<your-azure-openai-api-key>',
+    'AZURE_OPENAI_ENDPOINT': '<your-azure-openai-endpoint>',
+    'AZURE_OPENAI_EMBEDDING_DEPLOYMENT': '<your-azure-openai-embedding-deployment>',
+    'AZURE_SEARCH_KEY': '<your-azure-search-key>',
+    'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
+}
 
 @dataclass
 class Doc:
@@ -75,14 +89,14 @@ async def setup(search_api_key, search_api_endpoint):
 
     {{#useAzureOpenAI}}
     embeddings = AzureOpenAIEmbeddings(AzureOpenAIEmbeddingsOptions(
-        azure_api_key=os.getenv('AZURE_OPENAI_API_KEY'),
-        azure_endpoint=os.getenv('AZURE_OPENAI_ENDPOINT'),
-        azure_deployment=os.getenv('AZURE_OPENAI_EMBEDDING_DEPLOYMENT')
+        azure_api_key=config['AZURE_OPENAI_API_KEY'],
+        azure_endpoint=config['AZURE_OPENAI_ENDPOINT'],
+        azure_deployment=config['AZURE_OPENAI_EMBEDDING_DEPLOYMENT']
     ))
     {{/useAzureOpenAI}}
     {{#useOpenAI}}
     embeddings=OpenAIEmbeddings(OpenAIEmbeddingsOptions(
-        api_key=os.getenv('OPENAI_API_KEY'),
+        api_key=config['OPENAI_API_KEY'],
         model='text-embedding-ada-002'
     ))
     {{/useOpenAI}}
@@ -91,8 +105,8 @@ async def setup(search_api_key, search_api_endpoint):
 
     print("Upload new documents succeeded. If they do not exist, wait for several seconds...")
     
-search_api_key = os.getenv('AZURE_SEARCH_KEY')
-search_api_endpoint = os.getenv('AZURE_SEARCH_ENDPOINT')
+search_api_key = config['AZURE_SEARCH_KEY']
+search_api_endpoint = config['AZURE_SEARCH_ENDPOINT']
 asyncio.run(setup(search_api_key, search_api_endpoint))
 print("setup finished")
 

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
@@ -27,8 +27,6 @@ from teams.ai.embeddings import OpenAIEmbeddings, OpenAIEmbeddingsOptions
 
 from get_data import get_doc_data
 
-from dotenv import load_dotenv
-
 {{#useOpenAI}}
 config = {
     'OPENAI_API_KEY': '<your-openai-api-key>',

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
@@ -44,6 +44,7 @@ config = {
     'AZURE_SEARCH_KEY': '<your-azure-search-key>',
     'AZURE_SEARCH_ENDPOINT': '<your-azure-search-endpoint>'
 }
+{{/useAzureOpenAI}}
 
 @dataclass
 class Doc:

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
@@ -29,7 +29,7 @@ from get_data import get_doc_data
 
 from dotenv import load_dotenv
 
-load_dotenv(f'{os.getcwd()}/env/.env.local.user', override=True)
+load_dotenv(f'{os.getcwd()}/.env', override=True)
 
 @dataclass
 class Doc:
@@ -75,14 +75,14 @@ async def setup(search_api_key, search_api_endpoint):
 
     {{#useAzureOpenAI}}
     embeddings = AzureOpenAIEmbeddings(AzureOpenAIEmbeddingsOptions(
-        azure_api_key=os.getenv('SECRET_AZURE_OPENAI_API_KEY'),
+        azure_api_key=os.getenv('AZURE_OPENAI_API_KEY'),
         azure_endpoint=os.getenv('AZURE_OPENAI_ENDPOINT'),
         azure_deployment=os.getenv('AZURE_OPENAI_EMBEDDING_DEPLOYMENT')
     ))
     {{/useAzureOpenAI}}
     {{#useOpenAI}}
     embeddings=OpenAIEmbeddings(OpenAIEmbeddingsOptions(
-        api_key=os.getenv('SECRET_OPENAI_API_KEY'),
+        api_key=os.getenv('OPENAI_API_KEY'),
         model='text-embedding-ada-002'
     ))
     {{/useOpenAI}}
@@ -91,7 +91,7 @@ async def setup(search_api_key, search_api_endpoint):
 
     print("Upload new documents succeeded. If they do not exist, wait for several seconds...")
     
-search_api_key = os.getenv('SECRET_AZURE_SEARCH_KEY')
+search_api_key = os.getenv('AZURE_SEARCH_KEY')
 search_api_endpoint = os.getenv('AZURE_SEARCH_ENDPOINT')
 asyncio.run(setup(search_api_key, search_api_endpoint))
 print("setup finished")


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29178873

Api keys in `.env.*.user` are encrypted now. Python needs to decrypt them in scripts if keys are still loaded from `.env.*.user`. 
It is not a good idea to write decript code in opensource scripts, so we change guidances in readme and load paths.