### PR TITLE
fix: vulnerabilities of csharp templates

### DIFF
--- a/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
@@ -21,6 +21,8 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
@@ -19,7 +19,7 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
   </ItemGroup>

--- a/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
@@ -17,7 +17,7 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="AdaptiveCards" Version="2.7.3" />

--- a/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
@@ -17,11 +17,12 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/message-extension-copilot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-copilot/{{ProjectName}}.csproj.tpl
@@ -17,11 +17,12 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
@@ -17,11 +17,12 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
@@ -17,11 +17,12 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -17,9 +17,10 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/non-sso-tab/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/non-sso-tab/{{ProjectName}}.csproj.tpl
@@ -17,9 +17,10 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -36,6 +36,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->

--- a/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -31,6 +31,8 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->

--- a/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -35,6 +35,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -31,6 +31,8 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -36,6 +36,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->

--- a/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -31,6 +31,8 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -25,7 +25,9 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">

--- a/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -19,10 +19,10 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.38.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/sso-tab/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/sso-tab/{{ProjectName}}.csproj.tpl
@@ -19,10 +19,10 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.38.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
@@ -21,6 +21,8 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.36.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29181693

Some templates need to upgrade the NuGet packages to avoid vulnerabilities:
1. https://github.com/advisories/GHSA-3fx3-85r4-8j3w
2. https://github.com/advisories/GHSA-59j7-ghrg-fj52
3. https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

It is worth mentioning that different NET version (env) will install different versions of NuGet packages.

Adding new packages to solve is because `Microsoft.TeamsFx` or some packages use some vulnerable dependencies. Newest versions cannot solve vulnerabilities.