### PR TITLE
ci: update localization pipeline to use persistCredential instead of PAT

### DIFF
--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -69,7 +69,7 @@ extends:
             isAutoCompletePrSelected: false
             packageSourceAuth: patAuth
             patVariable: '$(System.AccessToken)'
-            dependencyPackageSource: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/ceapex.LocTools/nuget/v3/index.json'
+            dependencyPackageSource: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/TeamsFx/nuget/v3/index.json'
         - task: PowerShell@2
           displayName: Copy zh json files for VSC
           inputs:

--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -50,6 +50,7 @@ extends:
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: drop'
+            targetPath: '$(Build.ArtifactStagingDirectory)\loc'
         steps:
         - checkout: self
           clean: true

--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -55,6 +55,7 @@ extends:
         - checkout: self
           clean: true
           fetchTags: false
+          persistCredentials: true
         - task: NuGetAuthenticate@1
           displayName: NuGet Authenticate
           inputs:
@@ -67,6 +68,8 @@ extends:
             isShouldReusePrSelected: true
             isAutoCompletePrSelected: false
             packageSourceAuth: patAuth
+            patVariable: '$(System.AccessToken)'
+            dependencyPackageSource: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/ceapex.LocTools/nuget/v3/index.json'
         - task: PowerShell@2
           displayName: Copy zh json files for VSC
           inputs:

--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -51,6 +51,10 @@ extends:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: drop'
             targetPath: '$(Build.ArtifactStagingDirectory)\loc'
+            artifactName: drop
+            artifactType: Container
+            condition: succeeded()
+            sbomEnabled: false
         steps:
         - checkout: self
           clean: true

--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -69,7 +69,7 @@ extends:
             isAutoCompletePrSelected: false
             packageSourceAuth: patAuth
             patVariable: '$(System.AccessToken)'
-            dependencyPackageSource: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/TeamsFx/nuget/v3/index.json'
+            dependencyPackageSource: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/TeamsFx/nuget/v3/index.json
         - task: PowerShell@2
           displayName: Copy zh json files for VSC
           inputs:

--- a/.azure-pipelines/localization.yml
+++ b/.azure-pipelines/localization.yml
@@ -15,16 +15,14 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
 - name: 1espt.codesignvalidation.enforced
   value: false
-- name: GitHubPat
-  value: 
-- name: OneLocBuildPat
-  value: 
 - name: PipelineClassification_Audited
   value: Production
 - name: PipelineGovernanceStatus_Audited
   value: true
 - name: policy_service.build_task_injection.enabled
   value: true
+- name: TeamName
+  value: 'TeamsFx'
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:


### PR DESCRIPTION
Success run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10123018&view=results

1. Migrate pipeline to 1ES to fix security alert
2. Migrate to persistCredential(use system.accessToken) instead of PAT to fix auth broken
I'll disable the legacy pipeline https://devdiv.visualstudio.com/DevDiv/_build?definitionId=18482 for now and delete after the PR merged