### PR TITLE
fix: skip spec validation for apikey and oauth driver

### DIFF
--- a/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
@@ -32,7 +32,7 @@ export async function getDomain(
     allowMultipleParameters: true,
   });
   const listResult = await parser.list();
-  const operations = listResult.APIs.filter((value) => value.isValid);
+  const operations = listResult.APIs;
   const domains = operations
     .filter((value) => {
       const auth = value.auth;

--- a/packages/fx-core/src/component/driver/oauth/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/oauth/utility/utility.ts
@@ -46,7 +46,7 @@ export async function getandValidateOauthInfoFromSpec(
     allowMethods: ["get", "post", "put", "delete", "patch", "head", "connect", "options", "trace"],
   });
   const listResult = await parser.list();
-  const operations = listResult.APIs.filter((value) => value.isValid).filter((value) => {
+  const operations = listResult.APIs.filter((value) => {
     const auth = value.auth;
     return auth && auth.authScheme.type === "oauth2" && auth.name === args.name;
   });

--- a/packages/fx-core/tests/component/driver/oauth/create.test.ts
+++ b/packages/fx-core/tests/component/driver/oauth/create.test.ts
@@ -333,6 +333,79 @@ describe("CreateOauthDriver", () => {
     }
   });
 
+  it("happy path: read clientSecret, refreshurl from input with invalid api", async () => {
+    sinon
+      .stub(teamsDevPortalClient, "createOauthRegistration")
+      .callsFake(async (token, oauthRegistration) => {
+        expect(oauthRegistration.clientId).to.equals("mockedClientId");
+        expect(oauthRegistration.clientSecret).to.equals("mockedClientSecret");
+        expect(oauthRegistration.description).to.equals("test");
+        expect(oauthRegistration.authorizationEndpoint).to.equals("mockedAuthorizationUrl");
+        expect(oauthRegistration.scopes[0]).to.equals("mockedScope");
+        expect(oauthRegistration.targetUrlsShouldStartWith[0]).to.equals("https://test");
+        expect(oauthRegistration.tokenExchangeEndpoint).to.equals("mockedTokenUrl");
+        expect(oauthRegistration.tokenRefreshEndpoint).to.equal("mockedRefreshUrl");
+        expect(oauthRegistration.applicableToApps).to.equals(OauthRegistrationAppType.AnyApp);
+        expect(oauthRegistration.isPKCEEnabled).to.be.false;
+        expect(oauthRegistration.targetAudience).to.equals(
+          OauthRegistrationTargetAudience.AnyTenant
+        );
+        expect(oauthRegistration.m365AppId).to.equal("");
+        expect(oauthRegistration.identityProvider).to.equal("Custom");
+        return {
+          configurationRegistrationId: {
+            oAuthConfigId: "mockedRegistrationId",
+          },
+        };
+      });
+    sinon.stub(SpecParser.prototype, "list").resolves({
+      APIs: [
+        {
+          api: "api",
+          server: "https://test",
+          operationId: "get",
+          auth: {
+            name: "test",
+            authScheme: {
+              type: "oauth2",
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: "mockedAuthorizationUrl",
+                  tokenUrl: "mockedTokenUrl",
+                  scopes: {
+                    mockedScope: "description for mocked scope",
+                  },
+                },
+              },
+            },
+          },
+          isValid: false,
+          reason: [],
+        },
+      ],
+      allAPICount: 1,
+      validAPICount: 1,
+    });
+
+    const args: any = {
+      name: "test",
+      appId: "mockedAppId",
+      apiSpecPath: "mockedPath",
+      clientId: "mockedClientId",
+      clientSecret: "mockedClientSecret",
+      flow: "authorizationCode",
+      refreshUrl: "mockedRefreshUrl",
+      isPKCEEnabled: false,
+      identityProvider: "Custom",
+    };
+    const result = await createOauthDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result.result.isOk()).to.be.true;
+    if (result.result.isOk()) {
+      expect(result.result.value.get(outputKeys.configurationId)).to.equal("mockedRegistrationId");
+      expect(result.summaries.length).to.equal(1);
+    }
+  });
+
   it("should throw error is identityProvider is Custom but the authorization url is not Microsoft Entra endpoint", async () => {
     sinon
       .stub(teamsDevPortalClient, "createOauthRegistration")


### PR DESCRIPTION
bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/Dilithium/CY24Q3/2Wk/2Wk11%20(Aug%2025%20-%20Sep%2007)?workitem=29102467