### PR TITLE
refactor: remove preview tag for Python templates

### DIFF
--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -587,12 +587,7 @@ export function getLanguageOptions(inputs: Inputs): OptionItem[] {
     return [
       { id: ProgrammingLanguage.JS, label: "JavaScript" },
       { id: ProgrammingLanguage.TS, label: "TypeScript" },
-      {
-        id: ProgrammingLanguage.PY,
-        label: "Python",
-        detail: "",
-        description: getLocalizedString("core.createProjectQuestion.option.description.preview"),
-      },
+      { id: ProgrammingLanguage.PY, label: "Python" },
     ];
   } else {
     // other cases


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29321496

Removing `Preview` tag for Python CEC templates as the dependency was already public.