### PR TITLE
fix: hide the AAD in copilot extensions

### DIFF
--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -30,6 +30,7 @@ export class FeatureFlagName {
   static readonly SyncManifest = "TEAMSFX_SYNC_MANIFEST";
   static readonly EnvFileFunc = "TEAMSFX_ENV_FILE_FUNC";
   static readonly KiotaIntegration = "TEAMSFX_KIOTA_INTEGRATION";
+  static readonly ApiPluginAAD = "TEAMSFX_API_PLUGIN_AAD";
 }
 
 export interface FeatureFlag {
@@ -87,6 +88,10 @@ export class FeatureFlags {
   };
   static readonly KiotaIntegration = {
     name: FeatureFlagName.KiotaIntegration,
+    defaultValue: "false",
+  };
+  static readonly ApiPluginAAD = {
+    name: FeatureFlagName.ApiPluginAAD,
     defaultValue: "false",
   };
 }

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1045,11 +1045,11 @@ export function apiAuthQuestion(): SingleSelectQuestion {
       if (inputs[QuestionNames.MeArchitectureType] === MeArchitectureOptions.newApi().id) {
         options.push(ApiAuthOptions.apiKey(), ApiAuthOptions.microsoftEntra());
       } else if (inputs[QuestionNames.ApiPluginType] === ApiPluginStartOptions.newApi().id) {
-        options.push(
-          ApiAuthOptions.apiKey(),
-          ApiAuthOptions.microsoftEntra(),
-          ApiAuthOptions.oauth()
-        );
+        options.push(ApiAuthOptions.apiKey());
+        if (featureFlagManager.getBooleanValue(FeatureFlags.ApiPluginAAD)) {
+          options.push(ApiAuthOptions.microsoftEntra());
+        }
+        options.push(ApiAuthOptions.oauth());
       }
       return options;
     },

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1595,6 +1595,7 @@ describe("scaffold question", () => {
       beforeEach(() => {
         mockedEnvRestore = mockedEnv({
           [FeatureFlagName.CopilotExtension]: "true",
+          [FeatureFlagName.ApiPluginAAD]: "true",
         });
       });
 
@@ -1943,6 +1944,7 @@ describe("scaffold question", () => {
       it("traverse in cli", async () => {
         mockedEnvRestore = mockedEnv({
           TEAMSFX_CLI_DOTNET: "false",
+          [FeatureFlagName.ApiPluginAAD]: "true",
         });
 
         const inputs: Inputs = {
@@ -4174,6 +4176,7 @@ describe("scaffold question", () => {
     beforeEach(() => {
       mockedEnvRestore = mockedEnv({
         [FeatureFlagName.CopilotExtension]: "true",
+        [FeatureFlagName.ApiPluginAAD]: "true",
       });
     });
 
@@ -4212,6 +4215,40 @@ describe("scaffold question", () => {
           ApiAuthOptions.none(),
           ApiAuthOptions.apiKey(),
           ApiAuthOptions.microsoftEntra(),
+          ApiAuthOptions.oauth(),
+        ]);
+      }
+    });
+  });
+  describe("api plugin auth question (AAD disabled)", () => {
+    let mockedEnvRestore: RestoreFn;
+    const tools = new MockTools();
+    setTools(tools);
+    beforeEach(() => {
+      mockedEnvRestore = mockedEnv({
+        [FeatureFlagName.CopilotExtension]: "true",
+        [FeatureFlagName.ApiPluginAAD]: "false",
+      });
+    });
+
+    afterEach(() => {
+      if (mockedEnvRestore) {
+        mockedEnvRestore();
+      }
+    });
+
+    it("api plugin from scratch without AAD enabled", async () => {
+      const question = apiAuthQuestion();
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+      };
+      inputs[QuestionNames.ApiPluginType] = ApiPluginStartOptions.newApi().id;
+      assert.isDefined(question.dynamicOptions);
+      if (question.dynamicOptions) {
+        const options = (await question.dynamicOptions(inputs)) as OptionItem[];
+        assert.deepEqual(options, [
+          ApiAuthOptions.none(),
+          ApiAuthOptions.apiKey(),
           ApiAuthOptions.oauth(),
         ]);
       }


### PR DESCRIPTION
[Bug 29362457](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29362457): Add a new feature flag to hide the API Plugin with AAD template