### PR TITLE
fix: add plugin in command palette

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -906,6 +906,12 @@
         "category": "Teams"
       },
       {
+        "command": "fx-extension.addPlugin",
+        "title": "%teamstoolkit.commandsTreeViewProvider.addPluginTitle%",
+        "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked",
+        "category": "Teams"
+      },
+      {
         "command": "fx-extension.openOfficeDevLifecycleLink",
         "title": "%teamstoolkit.commands.lifecycleLink.title%",
         "icon": "$(info)"


### PR DESCRIPTION
[Bug 29397812](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29397812): Add Plugin is not available as a command