### PR TITLE
refactor: update the schema link for copilot extensions

### DIFF
--- a/packages/spec-parser/src/constants.ts
+++ b/packages/spec-parser/src/constants.ts
@@ -127,5 +127,5 @@ export class ConstantString {
   static readonly FunctionDescriptionMaxLens = 100;
   static readonly DefaultPluginId = "plugin_1";
   static readonly PluginManifestSchema =
-    "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json";
+    "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json";
 }

--- a/templates/csharp/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",
   "namespace": "repairs",

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/csharp/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",
   "namespace": "repairs",

--- a/templates/csharp/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
+++ b/templates/csharp/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",
   "namespace": "repairs",

--- a/templates/csharp/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/csharp/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This GPT helps you with finding car repair records.",

--- a/templates/js/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
+++ b/templates/js/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/js/api-plugin-from-scratch-bearer/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/js/api-plugin-from-scratch-bearer/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/js/api-plugin-from-scratch-oauth/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/js/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
+++ b/templates/js/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",
   "namespace": "repairs",

--- a/templates/js/api-plugin-from-scratch/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/js/api-plugin-from-scratch/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/js/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
+++ b/templates/js/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/js/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/js/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This GPT helps you with finding car repair records.",

--- a/templates/ts/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-bearer/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/ts/api-plugin-from-scratch-bearer/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-bearer/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.dev.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/ai-plugin.local.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/ts/api-plugin-from-scratch-oauth/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/ts/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
+++ b/templates/ts/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "{{appName}}${{APP_NAME_SUFFIX}}",

--- a/templates/ts/api-plugin-from-scratch/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/ts/api-plugin-from-scratch/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This declarative agent helps you with finding car repair records.",

--- a/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
+++ b/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/ai-plugin.json.tpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/json-schemas/copilot-extensions/v2.1/plugin.schema.json",
+  "$schema": "https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "namespace": "repairs",
   "name_for_human": "ttk-plugin-copilot${{APP_NAME_SUFFIX}}",

--- a/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
+++ b/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/repairDeclarativeAgent.json.tpl
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://aka.ms/json-schemas/copilot-extensions/vNext/declarative-copilot.schema.json",
+    "$schema": "https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json",
     "version": "v1.0",
     "name": "{{appName}}${{APP_NAME_SUFFIX}}",
     "description": "This GPT helps you with finding car repair records.",


### PR DESCRIPTION
Change the schema URL to the following link:

- Declarative Copilot: https://aka.ms/json-schemas/copilot/declarative-agent/v1.0/schema.json
- Plugin: https://aka.ms/json-schemas/copilot/plugin/v2.1/schema.json

Involving the following templates:

- API Plugin from scratch (None auth, API Key, AAD, OAuth).
- API Plugin from existing API.
- Basic Declarative Copilot.
- Declarative Copilot with a plugin (None auth, API Key, AAD, OAuth).
- Declarative Copilot with a plugin from existing API.
