### PR TITLE
fix: sample app tags are not read

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -45,7 +45,7 @@ export default class SampleCard extends React.Component<SampleProps, { imageUrl:
         <label className="hidden-label" id="tagLabel">
           sample app tags:
         </label>
-        <div className="tagSection" aria-labelledby="tagLabel">
+        <div className="tagSection">
           {sample.tags &&
             sample.tags.map((value: string) => {
               return (


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29506356
Before:
![image](https://github.com/user-attachments/assets/4df839fc-a2a9-4fdc-ba86-c52d961f3296)
After:
![image](https://github.com/user-attachments/assets/2c314723-6da2-470d-8e80-d9d1e002dc34)

![image](https://github.com/user-attachments/assets/76d2b160-d6c5-4768-99df-4bdf783ed467)

