### PR TITLE
fix: remove space in login error source

### DIFF
--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -36,7 +36,7 @@
   "teamstoolkit.capabilities.untrustedWorkspaces.description": "The Teams Toolkit extension supports limited features in untrusted workspaces.",
   "teamstoolkit.codeFlowLogin.loginCodeFlowFailureDescription": "Unable to get login code for token exchange. Log in with another account.",
   "teamstoolkit.codeFlowLogin.loginCodeFlowFailureTitle": "Login Code Error",
-  "teamstoolkit.codeFlowLogin.loginComponent": "Log In",
+  "teamstoolkit.codeFlowLogin.loginComponent": "Login",
   "teamstoolkit.codeFlowLogin.loginFailureDescription": "Unable to get user login information. Log in with another account.",
   "teamstoolkit.codeFlowLogin.loginFailureTitle": "Login unsuccessful",
   "teamstoolkit.codeFlowLogin.loginPortConflictDescription": "There was a delay in finding a login port. Please try again.",


### PR DESCRIPTION
ADO: 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29640658
Root cause:
This issue is introduced in [this PR](https://github.com/OfficeDev/teams-toolkit/pull/10955). As the content design stated: 'This change is recommended only if this content for CTA button.'. Since this is used as error source and will not be a CTA button, so revert this change.
