### PR TITLE
fix: reset env after import outlook addin (#12494)

### DIFF
--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -18,7 +18,6 @@ import {
   ok,
 } from "@microsoft/teamsfx-api";
 import * as childProcess from "child_process";
-import fse from "fs-extra";
 import { toLower } from "lodash";
 import { OfficeAddinManifest } from "office-addin-manifest";
 import { convertProject } from "office-addin-project";
@@ -39,6 +38,7 @@ import { DefaultTemplateGenerator } from "../templates/templateGenerator";
 import { TemplateInfo } from "../templates/templateInfo";
 import { convertToLangKey } from "../utils";
 import { HelperMethods } from "./helperMethods";
+import { envUtil } from "../../utils/envUtil";
 
 const componentName = "office-addin";
 const telemetryEvent = "generate";
@@ -258,5 +258,25 @@ export class OfficeAddinGeneratorNew extends DefaultTemplateGenerator {
     const res = await OfficeAddinGenerator.doScaffolding(context, inputs, destinationPath);
     if (res.isErr()) return err(res.error);
     return Promise.resolve(ok([{ templateName: tplName, language: lang }]));
+  }
+
+  async post(
+    context: Context,
+    inputs: Inputs,
+    destinationPath: string,
+    actionContext?: ActionContext
+  ): Promise<Result<GeneratorResult, FxError>> {
+    const fromFolder = inputs[QuestionNames.OfficeAddinFolder];
+    if (fromFolder) {
+      // reset all env files
+      const envRes = await envUtil.listEnv(destinationPath);
+      if (envRes.isOk()) {
+        const envs = envRes.value;
+        for (const env of envs) {
+          await envUtil.resetEnv(destinationPath, env, ["TEAMSFX_ENV", "APP_NAME_SUFFIX"]);
+        }
+      }
+    }
+    return ok({});
   }
 }

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -45,6 +45,7 @@ import {
   QuestionNames,
 } from "../../../src/question";
 import { MockTools } from "../../core/utils";
+import { envUtil } from "../../../src/component/utils/envUtil";
 
 describe("OfficeAddinGenerator for Outlook Addin", function () {
   const testFolder = path.resolve("./tmp");
@@ -1031,6 +1032,44 @@ describe("OfficeAddinGeneratorNew", () => {
       sandbox.stub(OfficeAddinGenerator, "doScaffolding").resolves(err(new UserCancelError()));
       const res = await generator.getTemplateInfos(context, inputs, "./");
       chai.assert.isTrue(res.isErr());
+    });
+  });
+  describe("post()", () => {
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it(`happy`, async () => {
+      sandbox.stub(envUtil, "listEnv").resolves(ok(["dev", "dev2"]));
+      const reset = sandbox.stub(envUtil, "resetEnv").resolves();
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: "./",
+      };
+      inputs[QuestionNames.OfficeAddinFolder] = "testfolder";
+      const res = await generator.post(context, inputs, "./");
+      chai.assert.isTrue(res.isOk());
+      chai.assert.isTrue(reset.calledTwice);
+    });
+    it(`not import`, async () => {
+      const reset = sandbox.stub(envUtil, "resetEnv").resolves();
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: "./",
+      };
+      const res = await generator.post(context, inputs, "./");
+      chai.assert.isTrue(res.isOk());
+      chai.assert.isTrue(reset.notCalled);
+    });
+    it(`list env error`, async () => {
+      sandbox.stub(envUtil, "listEnv").resolves(err(new UserCancelError()));
+      const reset = sandbox.stub(envUtil, "resetEnv").resolves();
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: "./",
+      };
+      const res = await generator.post(context, inputs, "./");
+      chai.assert.isTrue(res.isOk());
+      chai.assert.isTrue(reset.notCalled);
     });
   });
 });


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29792240