### PR TITLE
fix: refine prerequisite checker error message

### DIFF
--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -65,7 +65,9 @@ export class CliTelemetryReporter implements TelemetryReporter {
     this.reporter.sendTelemetryErrorEvent(eventName, properties, measurements, errorProps);
 
     void logger.debug(
-      `sendTelemetryErrorEvent ===> ${eventName}, properties: ${JSON.stringify(properties)}`
+      `sendTelemetryErrorEvent ===> ${eventName}, properties: ${JSON.stringify(
+        properties
+      )}, measurements: ${JSON.stringify(measurements)}`
     );
   }
 
@@ -89,7 +91,9 @@ export class CliTelemetryReporter implements TelemetryReporter {
     this.reporter.sendTelemetryEvent(eventName, properties, measurements);
 
     void logger.debug(
-      `sendTelemetryEvent ===> ${eventName}, properties: ${JSON.stringify(properties)}`
+      `sendTelemetryEvent ===> ${eventName}, properties: ${JSON.stringify(
+        properties
+      )}, measurements: ${JSON.stringify(measurements)}`
     );
   }
 

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -598,10 +598,7 @@ async function handleCheckResults(
 
     if (shouldStop) {
       await progressHelper?.stop(false);
-      const message =
-        getDefaultString(displayMessages.errorMessageKey) +
-        " " +
-        displayMessages.showDetailMessage();
+      const message = failures.map((f) => f.error?.message || "").join(", ");
 
       // show failure summary in display message
       const displayMessage =

--- a/packages/vscode-extension/src/telemetry/vscodeTelemetryReporter.ts
+++ b/packages/vscode-extension/src/telemetry/vscodeTelemetryReporter.ts
@@ -17,6 +17,7 @@ import {
 } from "@microsoft/teamsfx-core";
 import { configure, getLogger, Logger } from "log4js";
 import { workspaceUri } from "../globalVariables";
+import VSCodeLogger from "../commonlib/log";
 
 const TelemetryTestLoggerFile = "telemetryTest.log";
 
@@ -117,6 +118,11 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
       this.logTelemetryErrorEvent(eventName, properties, measurements, errorProps);
     } else {
       this.reporter.sendTelemetryErrorEvent(eventName, properties, measurements);
+      void VSCodeLogger.debug(
+        `sendTelemetryErrorEvent ===> ${eventName}, properties: ${JSON.stringify(
+          properties
+        )}, measurements: ${JSON.stringify(measurements)}`
+      );
     }
   }
 
@@ -144,6 +150,11 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
       this.logTelemetryEvent(eventName, properties, measurements);
     } else {
       this.reporter.sendTelemetryEvent(eventName, properties, measurements);
+      void VSCodeLogger.debug(
+        `sendTelemetryEvent ===> ${eventName}, properties: ${JSON.stringify(
+          properties
+        )}, measurements: ${JSON.stringify(measurements)}`
+      );
     }
   }
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29830127


1. output telemetry log when use set loglevel=debug in vscode extension
2. Refine refine prerequisite checker error message