### PR TITLE
fix: return correct manifest path for MSTeams Samples

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
@@ -107,8 +107,12 @@ export class ManifestUtils {
   }
 
   getTeamsAppManifestPath(projectPath: string): string {
-    const filePath = path.join(projectPath, "appPackage", "manifest.json");
-    return filePath;
+    // Samples from https://github.com/OfficeDev/Microsoft-Teams-Samples have the manifest in appManifest folder
+    const filePath = path.join(projectPath, "appManifest", "manifest.json");
+    if (fs.existsSync(filePath)) {
+      return filePath;
+    }
+    return path.join(projectPath, "appPackage", "manifest.json");
   }
 
   async addCapabilities(


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29888446