### PR TITLE
perf: replace primary constructors with standard constructors for .NET 6 compatibility

### DIFF
--- a/templates/csharp/custom-copilot-rag-custom-api/OpenAPIClient/RequestParams.cs
+++ b/templates/csharp/custom-copilot-rag-custom-api/OpenAPIClient/RequestParams.cs
@@ -1,10 +1,11 @@
 namespace OpenAPIClient
 {
-    public class RequestParams()
+    public class RequestParams
     {
         public object PathObject;
         public object QueryObject;
         public object HeaderObject;
         public object RequestBody;
+        public RequestParams() { }
     }
 }


### PR DESCRIPTION
[Bug 29971535](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29971535): [VS][Rag Custom API Bot] Local debug failed for dotnet 6.0