### PR TITLE
feat: add schema validation for default language file

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/utils/telemetry.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/telemetry.ts
@@ -15,6 +15,7 @@ export enum TelemetryPropertyKey {
   pluginValidationErrors = "plugin-validation-errors",
   gptValidationErrors = "gpt-validation-errors",
   gptActionValidationErrors = "gpt-action-validation-errors",
+  localizationValidationErrors = "localization-validation-errors",
 }
 
 export enum TelemetryPropertyValue {

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -114,6 +114,8 @@ export class ValidateManifestDriver implements StepDriver {
     if (localizationFilesValidationRes.isErr()) {
       return err(localizationFilesValidationRes.error);
     }
+    telemetryProperties[TelemetryPropertyKey.localizationValidationErrors] =
+      localizationFilesValidationRes.value.error.map((r: string) => r.replace(/\//g, "")).join(";");
 
     let declarativeCopilotValidationResult;
     let pluginValidationResult;

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -399,11 +399,20 @@ export class ValidateManifestDriver implements StepDriver {
     context: WrapDriverContext,
     manifest: TeamsAppManifest
   ): Promise<Result<{ error: string[]; filePath?: string }, FxError>> {
-    const additionalLanguages = manifest.localizationInfo?.additionalLanguages;
-    if (!additionalLanguages || additionalLanguages.length == 0) {
+    if (
+      manifest.localizationInfo?.additionalLanguages?.length == 0 &&
+      !manifest.localizationInfo?.defaultLanguageFile
+    ) {
       return ok({ error: [] });
     }
-    for (const language of additionalLanguages) {
+    const languageList = manifest.localizationInfo?.additionalLanguages || [];
+    if (manifest.localizationInfo?.defaultLanguageFile) {
+      languageList.push({
+        languageTag: manifest.localizationInfo.defaultLanguageTag,
+        file: manifest.localizationInfo.defaultLanguageFile,
+      });
+    }
+    for (const language of languageList) {
       const filePath = language?.file;
       if (!filePath) {
         return err(

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -350,6 +350,20 @@ describe("teamsApp/validateManifest", async () => {
       }
     });
 
+    it("should output errors when default language file validation fails", async () => {
+      const args: ValidateManifestArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.invalid.default.localization.manifest.json",
+      };
+      process.env.CONFIG_TEAMS_APP_NAME = "fakeName";
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert.isTrue(result.error.message.includes("2 failed"));
+      }
+    });
+
     it("should return error when validation throws exception", async () => {
       const args: ValidateManifestArgs = { manifestPath: "fakepath" };
       const manifest = { localizationInfo: { additionalLanguages: [{ file: "filePath" }] } } as any;

--- a/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/resources/en.invalid.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/resources/en.invalid.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.12/MicrosoftTeams.Localization.schema.json",
+    "name.short": "Name App",
+    "name.full": "Name App",
+    "description.short.fake": "Description Short Deutsch",
+    "description.full.fake": "Description Long Deutsch",
+    "staticTabs[0].name": "Home"
+}

--- a/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.invalid.default.localization.manifest.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.invalid.default.localization.manifest.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.19",
+    "version": "1.0.0",
+    "id": "${{ TEAMS_APP_ID }}",
+    "developer": {
+        "name": "Teams App, Inc.",
+        "websiteUrl": "https://www.example.com",
+        "privacyUrl": "https://www.example.com/termofuse",
+        "termsOfUseUrl": "https://www.example.com/privacy"
+    },
+    "icons": {
+        "color": "resources/color.png",
+        "outline": "resources/outline.png"
+    },
+    "name": {
+        "short": "${{ CONFIG_TEAMS_APP_NAME }}",
+        "full": "${{ CONFIG_TEAMS_APP_NAME }}"
+    },
+    "description": {
+        "short": "Short description of ${{ CONFIG_TEAMS_APP_NAME }}",
+        "full": "Full description of ${{ CONFIG_TEAMS_APP_NAME }}"
+    },
+    "accentColor": "#FFFFFF",
+    "composeExtensions": [],
+    "staticTabs": [],
+    "permissions": [
+        "identity",
+        "messageTeamMembers"
+    ],
+    "validDomains": [],
+    "localizationInfo": {
+        "defaultLanguageTag": "en",
+        "defaultLanguageFile": "resources/en.invalid.json"
+    }
+}


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29904765

Also added telemetry for localization errors
![image](https://github.com/user-attachments/assets/3e03d633-7114-412d-991f-776df8703326)
