### PR TITLE
fix: update CEA schema url and version(js/ts)

### DIFF
--- a/templates/js/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/js/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/js/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/js/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/js/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/js/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",

--- a/templates/ts/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
@@ -1,8 +1,8 @@
 {
     {{#CEAEnabled}} 
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
-    "version": "1.0.1",
+    "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",


### PR DESCRIPTION
update CEA schema url and version base on blackchoey's comments in https://github.com/OfficeDev/teams-toolkit/pull/12512