### PR TITLE
fix: update reference path base on teams.ai 1.5.3

### DIFF
--- a/templates/ts/custom-copilot-rag-azure-ai-search/src/app/customSayCommand.ts
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/src/app/customSayCommand.ts
@@ -1,6 +1,6 @@
 import { ActivityTypes, Channels, TurnContext } from "botbuilder";
-import { PredictedSayCommand, TurnState, Utilities, ClientCitation } from "@microsoft/teams-ai";
-import { AIEntity } from "@microsoft/teams-ai/lib/actions/SayCommand";
+import { PredictedSayCommand, TurnState, Utilities } from "@microsoft/teams-ai";
+import { AIEntity, ClientCitation } from "@microsoft/teams-ai/lib/types";
 
 export function sayCommand<TState extends TurnState = TurnState>(feedbackLoopEnabled = false) {
   return async (context: TurnContext, _state: TState, data: PredictedSayCommand) => {

--- a/templates/ts/custom-copilot-rag-customize/src/app/customSayCommand.ts
+++ b/templates/ts/custom-copilot-rag-customize/src/app/customSayCommand.ts
@@ -1,6 +1,6 @@
 import { ActivityTypes, Channels, TurnContext } from "botbuilder";
-import { PredictedSayCommand, TurnState, Utilities, ClientCitation } from "@microsoft/teams-ai";
-import { AIEntity } from "@microsoft/teams-ai/lib/actions/SayCommand";
+import { PredictedSayCommand, TurnState, Utilities } from "@microsoft/teams-ai";
+import { AIEntity, ClientCitation } from "@microsoft/teams-ai/lib/types";
 
 export function sayCommand<TState extends TurnState = TurnState>(feedbackLoopEnabled = false) {
   return async (context: TurnContext, _state: TState, data: PredictedSayCommand) => {

--- a/templates/ts/custom-copilot-rag-microsoft365/src/app/customSayCommand.ts
+++ b/templates/ts/custom-copilot-rag-microsoft365/src/app/customSayCommand.ts
@@ -1,6 +1,6 @@
 import { ActivityTypes, Channels, TurnContext } from "botbuilder";
-import { PredictedSayCommand, TurnState, Utilities, ClientCitation } from "@microsoft/teams-ai";
-import { AIEntity } from "@microsoft/teams-ai/lib/actions/SayCommand";
+import { PredictedSayCommand, TurnState, Utilities } from "@microsoft/teams-ai";
+import { AIEntity, ClientCitation } from "@microsoft/teams-ai/lib/types";
 
 export function sayCommand<TState extends TurnState = TurnState>(feedbackLoopEnabled = false) {
   return async (context: TurnContext, _state: TState, data: PredictedSayCommand) => {


### PR DESCRIPTION
fix bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30017009

reference path was changed due to teams.ai 1.5.3 upgrade: https://github.com/microsoft/teams-ai/pull/2120
so update relate template to fix this bug

