### PR TITLE
feat: e2e support for multi-tenant

### DIFF
--- a/packages/fx-core/src/component/m365/launchHelper.ts
+++ b/packages/fx-core/src/component/m365/launchHelper.ts
@@ -21,6 +21,7 @@ import { NotExtendedToM365Error } from "./errors";
 import { PackageService } from "./packageService";
 import { MosServiceEndpoint, MosServiceScope } from "./serviceConstant";
 import { officeBaseUrl, outlookBaseUrl, outlookCopilotAppId } from "./constants";
+import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
 
 export class LaunchHelper {
   private readonly m365TokenProvider: M365TokenProvider;
@@ -66,7 +67,9 @@ export class LaunchHelper {
         url = new URL(baseUrl);
         const tid = await this.getTidFromToken();
         if (tid) {
-          url.searchParams.append("tenantId", tid);
+          if (featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)) {
+            url.searchParams.append("tenantId", tid);
+          }
           url.searchParams.append("appTenantId", tid);
         }
         break;

--- a/packages/fx-core/src/component/m365/launchHelper.ts
+++ b/packages/fx-core/src/component/m365/launchHelper.ts
@@ -66,6 +66,7 @@ export class LaunchHelper {
         url = new URL(baseUrl);
         const tid = await this.getTidFromToken();
         if (tid) {
+          url.searchParams.append("tenantId", tid);
           url.searchParams.append("appTenantId", tid);
         }
         break;

--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -142,7 +142,8 @@ class ProvisionUtils {
       return err(new M365TokenJSONNotFoundError());
     }
     const tenantIdInToken = (appStudioTokenJson as any).tid;
-    const tenantUserName = (appStudioTokenJson as any).upn;
+    const tenantUserName =
+      (appStudioTokenJson as any).upn ?? (appStudioTokenJson as any).unique_name;
     if (!tenantIdInToken || !(typeof tenantIdInToken === "string")) {
       return err(new M365TenantIdNotFoundInTokenError());
     }

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -351,7 +351,10 @@ export async function listCollaborator(
             content: getLocalizedString("core.collaboration.TeamsAppOwner"),
             color: Colors.BRIGHT_WHITE,
           },
-          { content: teamsAppOwner.userPrincipalName, color: Colors.BRIGHT_MAGENTA },
+          {
+            content: teamsAppOwner.userPrincipalName ?? teamsAppOwner.displayName,
+            color: Colors.BRIGHT_MAGENTA,
+          },
           { content: `.\n`, color: Colors.BRIGHT_WHITE }
         );
       }

--- a/packages/fx-core/tests/component/m365/launchHelper.test.ts
+++ b/packages/fx-core/tests/component/m365/launchHelper.test.ts
@@ -44,7 +44,7 @@ describe("LaunchHelper", () => {
       chai.assert(result.isOk());
       chai.assert.equal(
         (result as any).value,
-        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&tenantId=test-tid&appTenantId=test-tid&login_hint=test-upn"
       );
     });
 
@@ -71,7 +71,7 @@ describe("LaunchHelper", () => {
       chai.assert(result.isOk());
       chai.assert.equal(
         (result as any).value,
-        "https://teams.microsoft.com/?appTenantId=test-tid&login_hint=test-upn"
+        "https://teams.microsoft.com/?tenantId=test-tid&appTenantId=test-tid&login_hint=test-upn"
       );
     });
 
@@ -98,7 +98,7 @@ describe("LaunchHelper", () => {
       chai.assert(result.isOk());
       chai.assert.equal(
         (result as any).value,
-        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&tenantId=test-tid&appTenantId=test-tid&login_hint=test-upn"
       );
     });
 
@@ -125,7 +125,7 @@ describe("LaunchHelper", () => {
       chai.assert(result.isOk());
       chai.assert.equal(
         (result as any).value,
-        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&tenantId=test-tid&appTenantId=test-tid&login_hint=test-upn"
       );
     });
 
@@ -152,7 +152,7 @@ describe("LaunchHelper", () => {
       chai.assert(result.isOk());
       chai.assert.equal(
         (result as any).value,
-        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&tenantId=test-tid&appTenantId=test-tid&login_hint=test-upn"
       );
     });
 

--- a/packages/fx-core/tests/component/m365/launchHelper.test.ts
+++ b/packages/fx-core/tests/component/m365/launchHelper.test.ts
@@ -11,13 +11,23 @@ import { PackageService } from "../../../src/component/m365/packageService";
 import { HubTypes } from "../../../src/question";
 import { outlookCopilotAppId } from "../../../src/component/m365/constants";
 import { MockedM365Provider } from "../../core/utils";
+import mockedEnv, { RestoreFn } from "mocked-env";
+import { FeatureFlagName } from "../../../src";
 
 describe("LaunchHelper", () => {
   const m365TokenProvider = new MockedM365Provider();
   const launchHelper = new LaunchHelper(m365TokenProvider);
+  let mockedEnvRestore: RestoreFn = () => {};
 
   afterEach(() => {
     sinon.restore();
+    mockedEnvRestore();
+  });
+
+  beforeEach(() => {
+    mockedEnvRestore = mockedEnv({
+      [FeatureFlagName.MultiTenant]: "true",
+    });
   });
 
   describe("getLaunchUrl", () => {

--- a/packages/fx-core/tests/component/m365/launchHelper.test.ts
+++ b/packages/fx-core/tests/component/m365/launchHelper.test.ts
@@ -58,6 +58,36 @@ describe("LaunchHelper", () => {
       );
     });
 
+    it("getLaunchUrl: Teams, signed in - multi tenant off", async () => {
+      mockedEnvRestore = mockedEnv({
+        [FeatureFlagName.MultiTenant]: "false",
+      });
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      const properties: ManifestProperties = {
+        capabilities: ["staticTab"],
+        id: "test-id",
+        version: "1.0.0",
+        manifestVersion: "1.16",
+        isApiME: false,
+        isSPFx: false,
+        isApiMeAAD: false,
+      };
+      const result = await launchHelper.getLaunchUrl(HubTypes.teams, "test-id", properties);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+      );
+    });
+
     it("getLaunchUrl: Teams, signed in, copilot plugin", async () => {
       sinon.stub(m365TokenProvider, "getStatus").resolves(
         ok({

--- a/packages/fx-core/tests/component/provisionUtils.test.ts
+++ b/packages/fx-core/tests/component/provisionUtils.test.ts
@@ -474,6 +474,36 @@ describe("provisionUtils", () => {
         chai.assert.isTrue(res.error instanceof M365TenantIdNotFoundInTokenError);
       }
     });
+
+    it("happy pass - upn", async () => {
+      mocker.stub(tools.tokenProvider.m365TokenProvider, "getAccessToken").resolves(ok(""));
+      mocker
+        .stub(tools.tokenProvider.m365TokenProvider, "getJsonObject")
+        .resolves(ok({ tid: "faked id", upn: "faked upn" }));
+      const res = await provisionUtils.getM365TenantId(tools.tokenProvider.m365TokenProvider);
+      chai.assert.isTrue(res.isOk());
+      if (res.isOk()) {
+        chai.assert.deepEqual(res.value, {
+          tenantIdInToken: "faked id",
+          tenantUserName: "faked upn",
+        });
+      }
+    });
+
+    it("happy pass - unique_name", async () => {
+      mocker.stub(tools.tokenProvider.m365TokenProvider, "getAccessToken").resolves(ok(""));
+      mocker
+        .stub(tools.tokenProvider.m365TokenProvider, "getJsonObject")
+        .resolves(ok({ tid: "faked id", unique_name: "faked unique name" }));
+      const res = await provisionUtils.getM365TenantId(tools.tokenProvider.m365TokenProvider);
+      chai.assert.isTrue(res.isOk());
+      if (res.isOk()) {
+        chai.assert.deepEqual(res.value, {
+          tenantIdInToken: "faked id",
+          tenantUserName: "faked unique name",
+        });
+      }
+    });
   });
   describe("arm", () => {
     let mockedEnvRestore: RestoreFn | undefined;

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -92,6 +92,12 @@ export class CodeFlowLogin {
         this.account = dataCache;
         this.status = loggedIn;
       }
+
+      if (featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)) {
+        const tenantCache = await loadTenantId(this.accountName);
+        const allAccounts = await this.msalTokenCache.getAllAccounts();
+        this.account = allAccounts.find((account) => account.tenantId == tenantCache);
+      }
     } else if (this.status !== loggingIn) {
       this.account = undefined;
       this.status = loggedOut;
@@ -392,11 +398,12 @@ export class CodeFlowLogin {
       if (tenantId) {
         const allAccounts = await this.msalTokenCache.getAllAccounts();
         tenantedAccount = allAccounts.find((account) => account.tenantId == tenantId);
+        this.account = tenantedAccount ?? this.account;
       }
 
       try {
         const res = await this.pca.acquireTokenSilent({
-          account: tenantedAccount ? tenantedAccount : this.account,
+          account: this.account,
           scopes: scopes,
           forceRefresh: tenantedAccount ? false : true,
           authority: tenantId ? BASE_AUTHORITY + tenantId : this.config.auth.authority,

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -95,8 +95,10 @@ export class CodeFlowLogin {
 
       if (featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)) {
         const tenantCache = await loadTenantId(this.accountName);
-        const allAccounts = await this.msalTokenCache.getAllAccounts();
-        this.account = allAccounts.find((account) => account.tenantId == tenantCache);
+        if (tenantCache) {
+          const allAccounts = await this.msalTokenCache.getAllAccounts();
+          this.account = allAccounts.find((account) => account.tenantId == tenantCache);
+        }
       }
     } else if (this.status !== loggingIn) {
       this.account = undefined;

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -9,6 +9,8 @@ import {
   Correlator,
   environmentNameManager,
   envUtil,
+  featureFlagManager,
+  FeatureFlags,
   Hub,
   isValidProject,
   isValidProjectV3,
@@ -223,7 +225,13 @@ async function generateAccountHint(includeTenantId = true): Promise<string> {
     }
   }
   if (includeTenantId && tenantId) {
-    return loginHint ? `tenantId=${tenantId}&appTenantId=${tenantId}&login_hint=${loginHint}` : "";
+    if (featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)) {
+      return loginHint
+        ? `tenantId=${tenantId}&appTenantId=${tenantId}&login_hint=${loginHint}`
+        : "";
+    } else {
+      return loginHint ? `appTenantId=${tenantId}&login_hint=${loginHint}` : "";
+    }
   } else {
     return loginHint ? `login_hint=${loginHint}` : "";
   }

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -223,7 +223,7 @@ async function generateAccountHint(includeTenantId = true): Promise<string> {
     }
   }
   if (includeTenantId && tenantId) {
-    return loginHint ? `appTenantId=${tenantId}&login_hint=${loginHint}` : "";
+    return loginHint ? `tenantId=${tenantId}&appTenantId=${tenantId}&login_hint=${loginHint}` : "";
   } else {
     return loginHint ? `login_hint=${loginHint}` : "";
   }


### PR DESCRIPTION
1> append `tenantId` parameter in debug & preview launch url
2> fallback to displayName when collaborator upn is null
3> fallback to unique_name when upn is null to avoid undefined display name for m365 account in provision confirm dialog
4> read m365 tenant id from env file instead of state.env.json file

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29860159