### PR TITLE
fix: end local debug session when launch test tool to avoid sending incorrect debug-all event

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -247,10 +247,10 @@ async function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent)
           endLocalDebugSession();
           return;
         }
+        await sendDebugAllEvent(undefined, { [TelemetryProperty.DebugTestTool]: "true" });
         // Need to endLocalDebugSession() here.
         // Otherwise, when user stops debugging, or task exits, it will incorrectly send an incorrect debug-all event with success=no
         endLocalDebugSession();
-        await sendDebugAllEvent(undefined, { [TelemetryProperty.DebugTestTool]: "true" });
       }
     }
   }

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -247,6 +247,9 @@ async function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent)
           endLocalDebugSession();
           return;
         }
+        // Need to endLocalDebugSession() here.
+        // Otherwise, when user stops debugging, or task exits, it will incorrectly send an incorrect debug-all event with success=no
+        endLocalDebugSession();
         await sendDebugAllEvent(undefined, { [TelemetryProperty.DebugTestTool]: "true" });
       }
     }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30076176
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30076176