### PR TITLE
fix: bad zero prompt for Python basic chat CEA

### DIFF
--- a/templates/python/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -57,7 +57,7 @@
                     "commands": [
                         {
                             "title": "How can you help me?",
-                            "description": "A sample prompt"
+                            "description": "How can you help me?"
                         },
                         {
                             "title": "How to develop TeamsToolkit app?",


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30132551