### PR TITLE
fix: env func

### DIFF
--- a/packages/fx-core/src/component/utils/envFunctionUtils.ts
+++ b/packages/fx-core/src/component/utils/envFunctionUtils.ts
@@ -138,7 +138,7 @@ async function readFileContent(
   fromPath: string
 ): Promise<Result<string, FxError>> {
   const ext = path.extname(filePath);
-  if (ext.toLowerCase() !== ".txt") {
+  if (ext.toLowerCase() !== ".txt" && ext.toLowerCase() !== ".md") {
     ctx.logProvider.error(
       getLocalizedString("core.envFunc.unsupportedFile.errorLog", filePath, "txt")
     );
@@ -150,7 +150,8 @@ async function readFileContent(
     try {
       let fileContent = await fs.readFile(absolutePath, "utf8");
       fileContent = stripBom(fileContent);
-      const processedFileContent = expandEnvironmentVariable(fileContent, envs);
+      let processedFileContent = expandEnvironmentVariable(fileContent, envs);
+      processedFileContent = processedFileContent.replace(/\r\n/g, "\n");
       return ok(processedFileContent);
     } catch (e) {
       ctx.logProvider.error(

--- a/packages/fx-core/tests/component/util/envFunctionUtils.test.ts
+++ b/packages/fx-core/tests/component/util/envFunctionUtils.test.ts
@@ -70,13 +70,16 @@ describe("expandVariableWithFunction", async () => {
       [FeatureFlagName.EnvFileFunc]: "true",
     });
     const content =
-      "description:\"$[file('testfile1.txt')]\",description2:\"$[file( file( 'C://testfile2.txt' ))] $[file(${{FILE_PATH}})]\"";
+      "description:\"$[file('testfile1.md')]\",description2:\"$[file( file( 'C://testfile2.txt' ))] $[file(${{FILE_PATH}})]\"";
     sandbox.stub(fs, "pathExists").resolves(true);
     sandbox.stub(fs, "readFile").callsFake((file: number | fs.PathLike) => {
       if (file.toString().endsWith("testfile1.txt")) {
         return Promise.resolve("description in ${{TEST_ENV}}" as any);
       } else if (file.toString().endsWith("testfile2.txt")) {
         return Promise.resolve("test/testfile1.txt" as any);
+      }
+      if (file.toString().endsWith("testfile1.md")) {
+        return Promise.resolve("description in ${{TEST_ENV}}" as any);
       } else {
         throw new Error("not support " + file);
       }
@@ -124,7 +127,7 @@ describe("expandVariableWithFunction", async () => {
       FILE_PATH: "testfile1.txt",
       [FeatureFlagName.EnvFileFunc]: "true",
     });
-    const content = "description:\"$[ file('testfile1.md')]\"C://test";
+    const content = "description:\"$[ file('testfile1.png')]\"C://test";
     const res = await expandVariableWithFunction(
       content,
       context as any,


### PR DESCRIPTION
Two fixes included in this PR:
- [Bug 29887497](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29887497): Allow ".md" in $[file({filepath})] function
- Replace "\r\n" with "\n"
