### PR TITLE
fix: replace \r\n with \n

### DIFF
--- a/packages/fx-core/src/component/utils/envFunctionUtils.ts
+++ b/packages/fx-core/src/component/utils/envFunctionUtils.ts
@@ -150,7 +150,8 @@ async function readFileContent(
     try {
       let fileContent = await fs.readFile(absolutePath, "utf8");
       fileContent = stripBom(fileContent);
-      const processedFileContent = expandEnvironmentVariable(fileContent, envs);
+      let processedFileContent = expandEnvironmentVariable(fileContent, envs);
+      processedFileContent = processedFileContent.replace(/\r\n/g, "\n");
       return ok(processedFileContent);
     } catch (e) {
       ctx.logProvider.error(


### PR DESCRIPTION
[Bug 30149474](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30149474): file() function used in manifest.json should replace '\r\n' with '\n'