### PR TITLE
fix: validation manifest format

### DIFF
--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -74,7 +74,11 @@ export class ManifestUtil {
       addFormats(ajv, ["uri", "email", "regex"]);
       validate = ajv.compile(schema);
     } else {
-      const ajv = new Ajv({ formats: { uri: true }, allErrors: true, strictTypes: false });
+      const ajv = new Ajv({
+        allErrors: true,
+        strictTypes: false,
+      });
+      addFormats(ajv, ["uri", "email", "regex"]);
       validate = ajv.compile(schema);
     }
 


### PR DESCRIPTION
* fix: add format
[Bug 30033654](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30033654): Validating a project with an API plugin using the manifest schema causes an error