### PR TITLE
fix: kill process tree sync

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1730,6 +1730,7 @@
     "dotenv": "^8.2.0",
     "dree": "^4.7.0",
     "express": "^4.21.1",
+    "find-process": "^1.4.4",
     "fuse.js": "^6.6.2",
     "glob": "^10",
     "jscodeshift": "^0.14.0",

--- a/packages/vscode-extension/pnpm-lock.yaml
+++ b/packages/vscode-extension/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   express:
     specifier: ^4.21.1
     version: 4.21.1
+  find-process:
+    specifier: ^1.4.4
+    version: 1.4.4
   fuse.js:
     specifier: ^6.6.2
     version: 6.6.2
@@ -468,7 +471,7 @@ packages:
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
-      '@azure/msal-browser': 3.26.1
+      '@azure/msal-browser': 3.27.0
       '@azure/msal-node': 2.6.6
       events: 3.3.0
       jws: 4.0.0
@@ -489,15 +492,15 @@ packages:
     resolution: {integrity: sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==}
     dev: false
 
-  /@azure/msal-browser@3.26.1:
-    resolution: {integrity: sha512-y78sr9g61aCAH9fcLO1um+oHFXc1/5Ap88RIsUSuzkm0BHzFnN+PXGaQeuM1h5Qf5dTnWNOd6JqkskkMPAhh7Q==}
+  /@azure/msal-browser@3.27.0:
+    resolution: {integrity: sha512-+b4ZKSD8+vslCtVRVetkegEhOFMLP3rxDWJY212ct+2r6jVg6OSQKc1Qz3kCoXo0FgwaXkb+76TMZfpHp8QtgA==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 14.15.0
+      '@azure/msal-common': 14.16.0
     dev: false
 
-  /@azure/msal-common@14.15.0:
-    resolution: {integrity: sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==}
+  /@azure/msal-common@14.16.0:
+    resolution: {integrity: sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==}
     engines: {node: '>=0.8.0'}
     dev: false
 
@@ -3145,7 +3148,7 @@ packages:
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
     dependencies:
       '@types/node': 14.14.21
-      '@types/qs': 6.9.16
+      '@types/qs': 6.9.17
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
     dev: true
@@ -3155,7 +3158,7 @@ packages:
     dependencies:
       '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 4.19.6
-      '@types/qs': 6.9.16
+      '@types/qs': 6.9.17
       '@types/serve-static': 1.15.7
     dev: true
 
@@ -3265,8 +3268,8 @@ packages:
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
     dev: true
 
-  /@types/qs@6.9.16:
-    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
+  /@types/qs@6.9.17:
+    resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
     dev: true
 
   /@types/range-parser@1.2.7:
@@ -4087,8 +4090,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001677
-      electron-to-chromium: 1.5.51
+      caniuse-lite: 1.0.30001678
+      electron-to-chromium: 1.5.52
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
 
@@ -4203,8 +4206,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001677:
-    resolution: {integrity: sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==}
+  /caniuse-lite@1.0.30001678:
+    resolution: {integrity: sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==}
 
   /chai-as-promised@7.1.1(chai@4.2.0):
     resolution: {integrity: sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==}
@@ -4467,6 +4470,11 @@ packages:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
     dev: false
 
+  /commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
@@ -4610,8 +4618,8 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
-  /cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+  /cross-spawn@7.0.5:
+    resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
     engines: {node: '>= 8'}
     dependencies:
       path-key: 3.1.1
@@ -5323,8 +5331,8 @@ packages:
       jake: 10.9.2
     dev: true
 
-  /electron-to-chromium@1.5.51:
-    resolution: {integrity: sha512-kKeWV57KSS8jH4alKt/jKnvHPmJgBxXzGUSbMd4eQF+iOsVPl7bz2KUmu6eo80eMP8wVioTfTyTzdMgM15WXNg==}
+  /electron-to-chromium@1.5.52:
+    resolution: {integrity: sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==}
 
   /elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
@@ -5783,7 +5791,7 @@ packages:
       '@humanwhocodes/config-array': 0.6.0
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
@@ -5898,7 +5906,7 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -6125,6 +6133,17 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
+  /find-process@1.4.4:
+    resolution: {integrity: sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 5.1.0
+      debug: 4.3.7(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -6165,8 +6184,8 @@ packages:
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  /flow-parser@0.251.1:
-    resolution: {integrity: sha512-8ZuLqJPlL/T9K3zFdr1m88Lx8JOoJluTTdyvN4uH5NT9zoIIFqbCDoXVhkHh022k2lhuAyFF27cu0BYKh5SmDA==}
+  /flow-parser@0.252.0:
+    resolution: {integrity: sha512-z8hKPUjZ33VLn4HVntifqmEhmolUMopysnMNzazoDqo1GLUkBsreLNsxETlKJMPotUWStQnen6SGvUNe1j4Hlg==}
     engines: {node: '>=0.4.0'}
     dev: false
 
@@ -6197,7 +6216,7 @@ packages:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       signal-exit: 3.0.7
     dev: true
 
@@ -7144,7 +7163,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       archy: 1.0.0
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
@@ -7230,7 +7249,7 @@ packages:
       '@babel/register': 7.25.9(@babel/core@7.26.0)
       babel-core: 7.0.0-bridge.0(@babel/core@7.26.0)
       chalk: 4.1.2
-      flow-parser: 0.251.1
+      flow-parser: 0.252.0
       graceful-fs: 4.2.11
       micromatch: 4.0.8
       neo-async: 2.6.2

--- a/packages/vscode-extension/src/debug/depsChecker/taskChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/taskChecker.ts
@@ -34,7 +34,7 @@ export async function checkAndInstallForTask(
       // terminate all running teamsfx tasks
       if (allRunningTeamsfxTasks.size > 0) {
         VsCodeLogInstance.info("Terminate all running teamsfx tasks.");
-        terminateAllRunningTeamsfxTasks();
+        await terminateAllRunningTeamsfxTasks();
       }
 
       const res = await _checkAndInstall(

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -187,7 +187,7 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
       debugConfiguration.teamsfxResolved = true;
     } catch (error: any) {
       void showError(error);
-      terminateAllRunningTeamsfxTasks();
+      await terminateAllRunningTeamsfxTasks();
       await vscode.debug.stopDebugging();
       // not for undefined
       if (telemetryIsRemote === false) {

--- a/packages/vscode-extension/src/utils/processUtil.ts
+++ b/packages/vscode-extension/src/utils/processUtil.ts
@@ -1,77 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { exec } from "child_process";
+import kill from "tree-kill";
 
 class ProcessUtil {
-  async getProcessId(port: number): Promise<string> {
+  // kill process and its child processes
+  async killProcess(pid: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      const command =
-        process.platform === "win32" ? `netstat -ano | findstr :${port}` : `lsof -i :${port}`;
-      exec(command, (error, stdout) => {
-        if (error) {
-          return reject(error);
-        }
-        if (stdout) {
-          if (process.platform === "win32") {
-            const lines = stdout.split("\n");
-            const pidLine = lines.find((line) => line.includes(`:${port}`));
-            if (pidLine) {
-              const pid = pidLine.trim().split(/\s+/).pop();
-              resolve(pid || "");
-            } else {
-              resolve("");
-            }
-          } else {
-            const pid = stdout.split("\n")[1]?.split(/\s+/)[1];
-            resolve(pid || "");
-          }
+      kill(pid, "SIGTERM", (err) => {
+        if (err) {
+          reject(err);
         } else {
-          resolve("");
-        }
-      });
-    });
-  }
-
-  async killProcess(pid: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const command = process.platform === "win32" ? `taskkill /PID ${pid} /F` : `kill -9 ${pid}`;
-      exec(command, (error) => {
-        if (error) {
-          return reject(error);
-        }
-        resolve();
-      });
-    });
-  }
-
-  async getProcessInfo(pid: number): Promise<string> {
-    if (process.platform === "win32") return await this.getProcessInfoWindows(pid);
-    else return await this.getProcessCommandLineMac(pid);
-  }
-
-  async getProcessInfoWindows(pid: number): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec(
-        `wmic process where ProcessId=${pid} get CommandLine /value`,
-        (error, stdout, stderr) => {
-          if (error) {
-            reject(error);
-          } else {
-            const commandLine = stdout.split("=")[1]?.trim();
-            resolve(commandLine || "No CommandLine found");
-          }
-        }
-      );
-    });
-  }
-
-  async getProcessCommandLineMac(pid: number): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec(`ps -p ${pid} -o command=`, (error, stdout, stderr) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(stdout.trim());
+          resolve();
         }
       });
     });

--- a/packages/vscode-extension/src/utils/processUtil.ts
+++ b/packages/vscode-extension/src/utils/processUtil.ts
@@ -4,8 +4,9 @@ import kill from "tree-kill";
 
 class ProcessUtil {
   // kill process and its child processes
-  async killProcess(pid: number): Promise<void> {
-    return new Promise((resolve, reject) => {
+  async killProcess(pid: number, timeout = 5000): Promise<void> {
+    const tPromise = timeoutPromise(timeout);
+    const killPromise = new Promise<void>((resolve, reject) => {
       kill(pid, "SIGTERM", (err) => {
         if (err) {
           reject(err);
@@ -14,6 +15,15 @@ class ProcessUtil {
         }
       });
     });
+    await Promise.race([tPromise, killPromise]);
   }
+}
+
+export function timeoutPromise(timeout: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error("Operation timeout"));
+    }, timeout);
+  });
 }
 export const processUtil = new ProcessUtil();

--- a/packages/vscode-extension/src/utils/processUtil.ts
+++ b/packages/vscode-extension/src/utils/processUtil.ts
@@ -16,5 +16,4 @@ class ProcessUtil {
     });
   }
 }
-
 export const processUtil = new ProcessUtil();

--- a/packages/vscode-extension/src/utils/processUtil.ts
+++ b/packages/vscode-extension/src/utils/processUtil.ts
@@ -2,12 +2,16 @@
 // Licensed under the MIT license.
 import kill from "tree-kill";
 
+export const killModule = {
+  killTree: kill,
+};
+
 class ProcessUtil {
   // kill process and its child processes
   async killProcess(pid: number, timeout = 5000): Promise<void> {
     const tPromise = timeoutPromise(timeout);
     const killPromise = new Promise<void>((resolve, reject) => {
-      kill(pid, "SIGTERM", (err) => {
+      killModule.killTree(pid, "SIGTERM", (err) => {
         if (err) {
           reject(err);
         } else {

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,9 +1,10 @@
 import { expect } from "chai";
-import child_process from "child_process";
+// import child_process from "child_process";
 import sinon from "sinon";
 import { processUtil } from "../../src/utils/processUtil";
 
 describe("ProcessUtil", () => {
+  const child_process = require("child_process");
   let execStub: any;
   const sandbox = sinon.createSandbox();
   beforeEach(() => {
@@ -15,23 +16,21 @@ describe("ProcessUtil", () => {
   });
 
   describe("killProcess", () => {
-    it("happy", async () => {
-      sandbox.stub(process, "platform").value("win32");
-      execStub.yields(null);
-      await processUtil.killProcess(1234);
-      expect(execStub.calledWith(`taskkill /PID 1234 /T /F`)).to.be.true;
-    });
+    // it("happy", async () => {
+    //   sandbox.stub(process, "platform").value("win32");
+    //   execStub.yields(null);
+    //   await processUtil.killProcess(1234);
+    //   expect(execStub.calledWith(`taskkill /PID 1234 /T /F`)).to.be.true;
+    // });
 
     it("error", async () => {
       sandbox.stub(process, "platform").value("win32");
       const error = new Error("exec error");
       execStub.yields(error);
       try {
-        await processUtil.killProcess(1234);
+        await processUtil.killProcess(-1);
         throw new Error("Expected method to reject.");
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
+      } catch (err) {}
     });
   });
 });

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -21,7 +21,6 @@ describe("ProcessUtil", () => {
     });
     it("happy", async () => {
       const killStub = sandbox.stub(killModule, "killTree");
-      sandbox.stub(process, "platform").value("win32");
       killStub.yields(null);
       await processUtil.killProcess(-1);
       chai.assert.isTrue(killStub.calledOnce);

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,12 +1,8 @@
-// import child_process from "child_process";
 import sinon from "sinon";
 import { processUtil } from "../../src/utils/processUtil";
 
 describe("ProcessUtil", () => {
-  let execStub: any;
   const sandbox = sinon.createSandbox();
-  beforeEach(() => {
-  });
 
   afterEach(() => {
     sandbox.restore();
@@ -15,8 +11,6 @@ describe("ProcessUtil", () => {
   describe("killProcess", () => {
     it("error", async () => {
       sandbox.stub(process, "platform").value("win32");
-      const error = new Error("exec error");
-      execStub.yields(error);
       try {
         await processUtil.killProcess(-1);
         throw new Error("Expected method to reject.");

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,7 +1,6 @@
 import sinon, { SinonFakeTimers, useFakeTimers } from "sinon";
 import * as chai from "chai";
-import { processUtil, timeoutPromise } from "../../src/utils/processUtil";
-
+import { killModule, processUtil, timeoutPromise } from "../../src/utils/processUtil";
 describe("ProcessUtil", () => {
   const sandbox = sinon.createSandbox();
 
@@ -11,13 +10,21 @@ describe("ProcessUtil", () => {
 
   describe("killProcess", () => {
     it("error", async () => {
-      sandbox.stub(process, "platform").value("win32");
+      const killStub = sandbox.stub(killModule, "killTree");
+      killStub.yields(new Error());
       try {
         await processUtil.killProcess(-1);
         chai.assert.fail("Expected promise to reject, but it resolved.");
       } catch (error) {
         chai.assert.isTrue(error instanceof Error);
       }
+    });
+    it("happy", async () => {
+      const killStub = sandbox.stub(killModule, "killTree");
+      sandbox.stub(process, "platform").value("win32");
+      killStub.yields(null);
+      await processUtil.killProcess(-1);
+      chai.assert.isTrue(killStub.calledOnce);
     });
   });
 });

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -17,16 +17,13 @@ describe("ProcessUtil", () => {
   describe("killProcess", () => {
     it("happy", async () => {
       sandbox.stub(process, "platform").value("win32");
-      const pid = "1234";
       execStub.yields(null);
-
       await processUtil.killProcess(1234);
-      expect(execStub.calledWith(`taskkill /PID ${pid} /T /F`)).to.be.true;
+      expect(execStub.calledWith(`taskkill /PID 1234 /T /F`)).to.be.true;
     });
 
     it("error", async () => {
-      sandbox.stub(process, "platform").value("linux");
-      const pid = "5678";
+      sandbox.stub(process, "platform").value("win32");
       const error = new Error("exec error");
       execStub.yields(error);
       try {

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
-import sinon from "sinon";
 import child_process from "child_process";
-import { processUtil } from "../../src/utils/processUtil"; // Adjust the import path as necessary
+import sinon from "sinon";
+import { processUtil } from "../../src/utils/processUtil";
 
 describe("ProcessUtil", () => {
   let execStub: any;
@@ -14,153 +14,23 @@ describe("ProcessUtil", () => {
     sandbox.restore();
   });
 
-  describe("getProcessId", () => {
-    it("should return the process ID on Windows", async () => {
-      const port = 8080;
-      const stdout = `TCP    0.0.0.0:${port}           0.0.0.0:0              LISTENING       1234`;
-      execStub.yields(null, stdout);
-      sandbox.stub(process, "platform").value("win32");
-      const pid = await processUtil.getProcessId(port);
-      expect(pid).to.equal("1234");
-    });
-
-    it("should return the process ID on Unix-based systems", async () => {
-      const port = 8080;
-      const stdout = `COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode      5678 user   22u  IPv4  0t0    TCP *:${port} (LISTEN)`;
-      sandbox.stub(process, "platform").value("linux");
-      execStub.yields(null, stdout);
-      const pid = await processUtil.getProcessId(port);
-      expect(pid).to.equal("5678");
-    });
-
-    it("should return an empty string if no process is found on Windows", async () => {
-      const port = 8080;
-      execStub.yields(null, "");
-      sandbox.stub(process, "platform").value("win32");
-      const pid = await processUtil.getProcessId(port);
-      expect(pid).to.equal("");
-    });
-    it("should return an empty string if no process is found on Windows", async () => {
-      const port = 8080;
-      execStub.yields(null, "abc");
-      sandbox.stub(process, "platform").value("win32");
-      const pid = await processUtil.getProcessId(port);
-      expect(pid).to.equal("");
-    });
-    it("should return an empty string if no process is found on Unix-based systems", async () => {
-      const port = 8080;
-      execStub.yields(null, "COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n");
-      sandbox.stub(process, "platform").value("linux");
-      const pid = await processUtil.getProcessId(port);
-      expect(pid).to.equal("");
-    });
-
-    it("should reject with an error if exec fails", async () => {
-      const port = 8080;
-      const error = new Error("exec error");
-      execStub.yields(error, "");
-      try {
-        await processUtil.getProcessId(port);
-        throw new Error("Expected method to reject.");
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
-    });
-  });
-
   describe("killProcess", () => {
-    it("should kill the process on Windows", async () => {
+    it("happy", async () => {
       sandbox.stub(process, "platform").value("win32");
       const pid = "1234";
       execStub.yields(null);
 
-      await processUtil.killProcess(pid);
-      expect(execStub.calledWith(`taskkill /PID ${pid} /F`)).to.be.true;
+      await processUtil.killProcess(1234);
+      expect(execStub.calledWith(`taskkill /PID ${pid} /T /F`)).to.be.true;
     });
 
-    it("should kill the process on Unix-based systems", async () => {
-      sandbox.stub(process, "platform").value("linux");
-      const pid = "5678";
-      execStub.yields(null);
-
-      await processUtil.killProcess(pid);
-      expect(execStub.calledWith(`kill -9 ${pid}`)).to.be.true;
-    });
-
-    it("should reject with an error if exec fails on Windows", async () => {
-      sandbox.stub(process, "platform").value("win32");
-      const pid = "1234";
-      const error = new Error("exec error");
-      execStub.yields(error);
-
-      try {
-        await processUtil.killProcess(pid);
-        throw new Error("Expected method to reject.");
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
-    });
-
-    it("should reject with an error if exec fails on Unix-based systems", async () => {
+    it("error", async () => {
       sandbox.stub(process, "platform").value("linux");
       const pid = "5678";
       const error = new Error("exec error");
       execStub.yields(error);
-
       try {
-        await processUtil.killProcess(pid);
-        throw new Error("Expected method to reject.");
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
-    });
-  });
-
-  describe("getProcessInfo", () => {
-    it("should return process info on Unix-based systems", async () => {
-      sandbox.stub(process, "platform").value("linux");
-      const pid = 5678;
-      const stdout = `5678 /usr/bin/node`;
-      execStub.yields(null, stdout);
-
-      const processInfo = await processUtil.getProcessInfo(pid);
-      expect(processInfo).to.equal(stdout);
-      expect(execStub.calledWith(`ps -p ${pid} -o command=`)).to.be.true;
-    });
-
-    it("should return process info on Windows", async () => {
-      sandbox.stub(process, "platform").value("win32");
-      const pid = 1234;
-      const stdout = `CommandLine="node.exe"`;
-      execStub.yields(null, stdout);
-
-      const processInfo = await processUtil.getProcessInfo(pid);
-      expect(processInfo).to.equal('"node.exe"');
-      expect(execStub.calledWith(`wmic process where ProcessId=${pid} get CommandLine /value`)).to
-        .be.true;
-    });
-
-    it("should reject with an error if exec fails linux", async () => {
-      sandbox.stub(process, "platform").value("linux");
-      const pid = 5678;
-      const error = new Error("exec error");
-      execStub.yields(error);
-
-      try {
-        await processUtil.getProcessInfo(pid);
-        throw new Error("Expected method to reject.");
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
-    });
-    it("should reject with an error if exec fails win32", async () => {
-      sandbox.stub(process, "platform").value("win32");
-      const pid = 5678;
-      const error = new Error("exec error");
-      execStub.yields(error);
-
-      try {
-        await processUtil.getProcessInfo(pid);
+        await processUtil.killProcess(1234);
         throw new Error("Expected method to reject.");
       } catch (err) {
         expect(err).to.equal(error);

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,5 +1,6 @@
-import sinon from "sinon";
-import { processUtil } from "../../src/utils/processUtil";
+import sinon, { SinonFakeTimers, useFakeTimers } from "sinon";
+import * as chai from "chai";
+import { processUtil, timeoutPromise } from "../../src/utils/processUtil";
 
 describe("ProcessUtil", () => {
   const sandbox = sinon.createSandbox();
@@ -13,8 +14,35 @@ describe("ProcessUtil", () => {
       sandbox.stub(process, "platform").value("win32");
       try {
         await processUtil.killProcess(-1);
-        throw new Error("Expected method to reject.");
-      } catch (err) {}
+        chai.assert.fail("Expected promise to reject, but it resolved.");
+      } catch (error) {
+        chai.assert.isTrue(error instanceof Error);
+      }
     });
+  });
+});
+
+describe("timeoutPromise", () => {
+  let clock: SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("timeoutPromise", async () => {
+    try {
+      const timeout = 1000;
+      const promise = timeoutPromise(timeout);
+      clock.tick(timeout);
+      await promise;
+      chai.assert.fail("Expected promise to reject, but it resolved.");
+    } catch (error) {
+      chai.assert.isTrue(error instanceof Error);
+      chai.assert.equal(error.message, "Operation timeout");
+    }
   });
 });

--- a/packages/vscode-extension/test/utils/processUtil.test.ts
+++ b/packages/vscode-extension/test/utils/processUtil.test.ts
@@ -1,14 +1,11 @@
-import { expect } from "chai";
 // import child_process from "child_process";
 import sinon from "sinon";
 import { processUtil } from "../../src/utils/processUtil";
 
 describe("ProcessUtil", () => {
-  const child_process = require("child_process");
   let execStub: any;
   const sandbox = sinon.createSandbox();
   beforeEach(() => {
-    execStub = sandbox.stub(child_process, "exec");
   });
 
   afterEach(() => {
@@ -16,13 +13,6 @@ describe("ProcessUtil", () => {
   });
 
   describe("killProcess", () => {
-    // it("happy", async () => {
-    //   sandbox.stub(process, "platform").value("win32");
-    //   execStub.yields(null);
-    //   await processUtil.killProcess(1234);
-    //   expect(execStub.calledWith(`taskkill /PID 1234 /T /F`)).to.be.true;
-    // });
-
     it("error", async () => {
       sandbox.stub(process, "platform").value("win32");
       const error = new Error("exec error");


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30162620

The root cause of this bug is that TTK check ports immediately after killing the process that occupies the ports and the killing is not finished. So the kill process behavior should be executed in a sync mode to avoid this issue.