### PR TITLE
fix(vsc): blank sample detail page on codespaces

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.tsx
@@ -120,7 +120,11 @@ export default class SampleDetailPage extends React.Component<SampleProps, Sampl
   }
 
   private messageHandler = (event: any) => {
-    if ((event.origin as string).startsWith("vscode-webview")) {
+    // Allow client and codespaces.
+    if (
+      (event.origin as string).startsWith("vscode-webview") ||
+      (event.origin as string).endsWith("github.dev")
+    ) {
       const message = event.data.message;
       switch (message) {
         case Commands.LoadSampleReadme:


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29825293