### PR TITLE
fix: update running pattern to include 'ready' status

### DIFF
--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -58,7 +58,8 @@ export const funcHostedBotStartPattern =
   /Worker process started and initialized|Host lock lease acquired by instance ID/g;
 export const funcHostedBotAzuritePattern = /successfully listening/g;
 export const gulpServePattern = /^.*Finished subtask 'reload'.*/g;
-export const defaultRunningPattern = /started|successfully|finished|crashed|failed|listening/i;
+export const defaultRunningPattern =
+  /started|successfully|finished|crashed|failed|listening|ready/i;
 
 export const spfxInstallStartMessage = `executing 'npm install' under ${FolderName.SPFx} folder.`;
 export const gulpCertTitle = "gulp trust-dev-cert";


### PR DESCRIPTION
[Bug 30091455](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30091455): [CLI] sample "teams central dashboard" use "preview" command will stuck in progress

After migrating to Vite from react-script, the ready signal output indicating that the service is launched should also be updated.

The output while using vite:
```
> team-central-dashboard@0.1.0 dev:teamsfx
> env-cmd --silent -f .localConfigs npm run start


> team-central-dashboard@0.1.0 start
> vite

Port 53000 is in use, trying another one...

  VITE v5.4.11  ready in 567 ms

  ➜  Local:   https://localhost:53001/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
```
So, we should add a new state string 'ready'.