### PR TITLE
fix: remote debug 403 error in API Plugin with AAD template

### DIFF
--- a/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -40,7 +40,12 @@
 {{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
+{{#MicrosoftEntra}}
+           "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect",
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",
+{{/MicrosoftEntra}}
            "type": "Web"
         }
     ],

--- a/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/csharp/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -13,7 +13,6 @@ param location string = resourceGroup().location
 param serverfarmsName string = resourceBaseName
 param functionAppName string = resourceBaseName
 
-
 // Compute resources for Azure Functions
 resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
@@ -81,6 +80,9 @@ var aadApplicationIdUriWithDomain = 'api://${functionApp.properties.defaultHostN
 {{/MicrosoftEntra}}
 
 // Configure Azure Functions to use Azure AD for authentication.
+{{#MicrosoftEntra}}
+var clientIdForTGS = 'ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b'
+{{/MicrosoftEntra}}
 resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
   parent: functionApp
   name: 'authsettingsV2'
@@ -97,6 +99,14 @@ resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
           clientId: aadAppClientId
         }
         validation: {
+{{#MicrosoftEntra}}
+          defaultAuthorizationPolicy: {
+            allowedApplications: [
+              aadAppClientId
+              clientIdForTGS
+            ]
+          }
+{{/MicrosoftEntra}}
           allowedAudiences: [
             aadAppClientId
             aadApplicationIdUri

--- a/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -40,7 +40,12 @@
 {{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
+{{#MicrosoftEntra}}
+           "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect",
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",
+{{/MicrosoftEntra}}
            "type": "Web"
         }
     ],

--- a/templates/js/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -13,7 +13,6 @@ param location string = resourceGroup().location
 param serverfarmsName string = resourceBaseName
 param functionAppName string = resourceBaseName
 
-
 // Compute resources for Azure Functions
 resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
@@ -81,6 +80,9 @@ var aadApplicationIdUriWithDomain = 'api://${functionApp.properties.defaultHostN
 {{/MicrosoftEntra}}
 
 // Configure Azure Functions to use Azure AD for authentication.
+{{#MicrosoftEntra}}
+var clientIdForTGS = 'ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b'
+{{/MicrosoftEntra}}
 resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
   parent: functionApp
   name: 'authsettingsV2'
@@ -97,6 +99,14 @@ resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
           clientId: aadAppClientId
         }
         validation: {
+{{#MicrosoftEntra}}
+          defaultAuthorizationPolicy: {
+            allowedApplications: [
+              aadAppClientId
+              clientIdForTGS
+            ]
+          }
+{{/MicrosoftEntra}}
           allowedAudiences: [
             aadAppClientId
             aadApplicationIdUri

--- a/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/aad.manifest.json.tpl
@@ -40,7 +40,12 @@
 {{/MicrosoftEntra}}
     "replyUrlsWithType": [
         {
+{{#MicrosoftEntra}}
+           "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect",
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
            "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",
+{{/MicrosoftEntra}}
            "type": "Web"
         }
     ],

--- a/templates/ts/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/infra/azure.bicep.tpl
@@ -13,7 +13,6 @@ param location string = resourceGroup().location
 param serverfarmsName string = resourceBaseName
 param functionAppName string = resourceBaseName
 
-
 // Compute resources for Azure Functions
 resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
@@ -81,6 +80,9 @@ var aadApplicationIdUriWithDomain = 'api://${functionApp.properties.defaultHostN
 {{/MicrosoftEntra}}
 
 // Configure Azure Functions to use Azure AD for authentication.
+{{#MicrosoftEntra}}
+var clientIdForTGS = 'ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b'
+{{/MicrosoftEntra}}
 resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
   parent: functionApp
   name: 'authsettingsV2'
@@ -97,6 +99,14 @@ resource authSettings 'Microsoft.Web/sites/config@2021-02-01' = {
           clientId: aadAppClientId
         }
         validation: {
+{{#MicrosoftEntra}}
+          defaultAuthorizationPolicy: {
+            allowedApplications: [
+              aadAppClientId
+              clientIdForTGS
+            ]
+          }
+{{/MicrosoftEntra}}
           allowedAudiences: [
             aadAppClientId
             aadApplicationIdUri


### PR DESCRIPTION
Fix: [Bug 30266021](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30266021): [stable hotfix]Remote debug will get 403 forbidden for declarative/api plugin Microsoft Entra project

Cherry-pick https://github.com/OfficeDev/teams-toolkit/pull/12415