### PR TITLE
feat: deep link for declarative agents

### DIFF
--- a/packages/vscode-extension/src/debug/common/debugConstants.ts
+++ b/packages/vscode-extension/src/debug/common/debugConstants.ts
@@ -47,6 +47,8 @@ export enum Host {
 }
 
 export const accountHintPlaceholder = "${account-hint}";
+export const agentHintPlaceholder = "${agent-hint}";
+export const m365AppIdEnv = "M365_APP_ID";
 
 export const openOutputMessage = () =>
   util.format(

--- a/packages/vscode-extension/src/debug/common/types.ts
+++ b/packages/vscode-extension/src/debug/common/types.ts
@@ -31,3 +31,35 @@ export type PrerequisiteOrderedChecker = {
   info: PrerequisiteCheckerInfo;
   fastFail: boolean;
 };
+
+/**
+ * Represents the agent hint data structure used for debugging Teams apps
+ */
+export interface AgentHintData {
+  /**
+   * The M365 app ID from the environment variables
+   */
+  id: string;
+
+  /**
+   * The scenario identifier for the debug session
+   * Currently only supports "launchcopilotextension"
+   */
+  scenario: "launchcopilotextension";
+
+  /**
+   * Additional properties for the agent hint
+   */
+  properties: {
+    /**
+     * Timestamp when the debug session was initiated
+     */
+    clickTimestamp: string;
+  };
+
+  /**
+   * Version number of the agent hint format
+   * Currently set to 1
+   */
+  version: 1;
+}


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30207172

I'm adding a placeholder(`${agent-hint}`) in the launch URL of the declarative agents to enable deep linking for agents.

The template changes will be in a separate PR.